### PR TITLE
More version abstraction for Gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,11 @@
 kotlin.code.style=official
-kotlin.mpp.stability.nowarn=true
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false
 kotlin.js.generate.executable.default=false
-
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.mpp.stability.nowarn=true
+kotlin.native.enableDependencyPropagation=false
+# Plugin and dependency versions
+kotestVersion=4.6.1
 kotlinCoroutinesVersion=1.5.1
 kotlinSerialisationJsonVersion=1.2.2
-kotestVersion=4.6.1
+kotlinVersion=1.5.21
+versionsPluginVersion=0.39.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,9 +19,12 @@
 rootProject.name = "klogging"
 
 pluginManagement {
+    val kotlinVersion: String by settings
+    val versionsPluginVersion: String by settings
+
     plugins {
-        kotlin("multiplatform") version "1.5.21"
-        kotlin("plugin.serialization") version "1.5.21"
-        id("com.github.ben-manes.versions") version "0.39.0"
+        kotlin("multiplatform") version kotlinVersion
+        kotlin("plugin.serialization") version kotlinVersion
+        id("com.github.ben-manes.versions") version versionsPluginVersion
     }
 }


### PR DESCRIPTION
Take more advantage of specifying versions of things in `gradle.properties`.  Lean towards providing a single "source of truth" location, so easier for folks to see what dependencies and versions are, and easier to edit & maintain.