### PR TITLE
Continued: Version abstraction for Gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,9 +37,11 @@ repositories {
     mavenCentral()
 }
 
+val jacocoVersion: String by project
 val kotlinCoroutinesVersion: String by project
 val kotlinSerialisationJsonVersion: String by project
 val kotestVersion: String by project
+val ktlintVersion: String by project
 
 kotlin {
     explicitApi()
@@ -92,9 +94,9 @@ kotlin {
 }
 
 configureAssemble()
-configureJacoco()
+configureJacoco(jacocoVersion)
 configurePublishing()
-configureSpotless()
+configureSpotless(ktlintVersion)
 configureTesting()
 configureVersioning()
 configureWrapper()

--- a/buildSrc/src/main/kotlin/io/klogging/build/JacocoConfiguration.kt
+++ b/buildSrc/src/main/kotlin/io/klogging/build/JacocoConfiguration.kt
@@ -26,15 +26,16 @@ import org.gradle.testing.jacoco.plugins.JacocoPlugin
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.tasks.JacocoReport
 
-fun Project.configureJacoco() {
+fun Project.configureJacoco(jacocoVersion: String) {
     apply<JacocoPlugin>()
 
     configure<JacocoPluginExtension> {
-        toolVersion = "0.8.7"
+        toolVersion = jacocoVersion
     }
 
     tasks.named<JacocoReport>("jacocoTestReport") {
         reports {
+            html.required.set(true)
             xml.required.set(true)
         }
     }

--- a/buildSrc/src/main/kotlin/io/klogging/build/SpotlessConfiguration.kt
+++ b/buildSrc/src/main/kotlin/io/klogging/build/SpotlessConfiguration.kt
@@ -46,10 +46,10 @@ $licenceText
 
 """
 
-fun Project.configureSpotless() {
+fun Project.configureSpotless(ktlintVersion: String) {
     apply<SpotlessPlugin>()
 
-    configure<SpotlessExtension>() {
+    configure<SpotlessExtension> {
         format("misc") {
             target(
                 fileTree(
@@ -68,7 +68,7 @@ fun Project.configureSpotless() {
 
         kotlinGradle {
             target("*.gradle.kts", "gradle/*.gradle.kts", "buildSrc/*.gradle.kts")
-            ktlint("0.41.0")
+            ktlint(ktlintVersion)
 
             @Suppress("INACCESSIBLE_TYPE")
             licenseHeader(kotlinLicenceHeader, "import|tasks|apply|plugins|rootProject")
@@ -80,7 +80,7 @@ fun Project.configureSpotless() {
 
         kotlin {
             target("src/**/*.kt", "buildSrc/**/*.kt")
-            ktlint("0.41.0")
+            ktlint(ktlintVersion)
 
             @Suppress("INACCESSIBLE_TYPE")
             licenseHeader(kotlinLicenceHeader)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,10 @@ kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.enableDependencyPropagation=false
 # Plugin and dependency versions
+jacocoVersion=0.8.7
 kotestVersion=4.6.1
 kotlinCoroutinesVersion=1.5.1
 kotlinSerialisationJsonVersion=1.2.2
 kotlinVersion=1.5.21
+ktlintVersion=0.41.0
 versionsPluginVersion=0.39.0


### PR DESCRIPTION
I believe this PR has the last 2 spots in where version numbers are buried in `buildSrc`.  This PR gathers plugin versions in `gradle.properties`.