### PR TITLE
Rationalize package space (`Level` and `Logging`)

### DIFF
--- a/src/commonMain/kotlin/io/klogging/BaseLogger.kt
+++ b/src/commonMain/kotlin/io/klogging/BaseLogger.kt
@@ -19,7 +19,6 @@
 package io.klogging
 
 import io.klogging.config.KloggingConfiguration
-import io.klogging.events.Level
 
 /**
  * Base interface of [Klogger] interface for use in coroutines and

--- a/src/commonMain/kotlin/io/klogging/Klogger.kt
+++ b/src/commonMain/kotlin/io/klogging/Klogger.kt
@@ -18,7 +18,6 @@
 
 package io.klogging
 
-import io.klogging.events.Level
 import io.klogging.events.LogEvent
 
 /**

--- a/src/commonMain/kotlin/io/klogging/Level.kt
+++ b/src/commonMain/kotlin/io/klogging/Level.kt
@@ -16,7 +16,7 @@
 
 */
 
-package io.klogging.events
+package io.klogging
 
 import kotlinx.serialization.Serializable
 

--- a/src/commonMain/kotlin/io/klogging/NoCoLogger.kt
+++ b/src/commonMain/kotlin/io/klogging/NoCoLogger.kt
@@ -18,7 +18,6 @@
 
 package io.klogging
 
-import io.klogging.events.Level
 import io.klogging.events.LogEvent
 
 /**

--- a/src/commonMain/kotlin/io/klogging/config/Defaults.kt
+++ b/src/commonMain/kotlin/io/klogging/config/Defaults.kt
@@ -18,8 +18,8 @@
 
 package io.klogging.config
 
+import io.klogging.Level
 import io.klogging.dispatching.STDOUT
-import io.klogging.events.Level
 import io.klogging.rendering.RENDER_SIMPLE
 
 /** Simple sink configuration for rendering simple strings to the standard output stream. */

--- a/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
@@ -53,10 +53,7 @@ public data class JsonSinkConfiguration(
     internal fun toSinkConfiguration(): SinkConfiguration? {
         val renderer = BUILT_IN_RENDERERS[renderWith]
         val dispatcher = BUILT_IN_DISPATCHERS[dispatchTo]
-        return if (renderer != null && dispatcher != null) SinkConfiguration(
-            renderer,
-            dispatcher
-        )
+        return if (renderer != null && dispatcher != null) SinkConfiguration(renderer, dispatcher)
         else null
     }
 }

--- a/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
@@ -18,10 +18,10 @@
 
 package io.klogging.config
 
+import io.klogging.Level
 import io.klogging.dispatching.DispatchString
 import io.klogging.dispatching.STDERR
 import io.klogging.dispatching.STDOUT
-import io.klogging.events.Level
 import io.klogging.internal.warn
 import io.klogging.rendering.RENDER_CLEF
 import io.klogging.rendering.RENDER_GELF
@@ -53,7 +53,10 @@ public data class JsonSinkConfiguration(
     internal fun toSinkConfiguration(): SinkConfiguration? {
         val renderer = BUILT_IN_RENDERERS[renderWith]
         val dispatcher = BUILT_IN_DISPATCHERS[dispatchTo]
-        return if (renderer != null && dispatcher != null) SinkConfiguration(renderer, dispatcher)
+        return if (renderer != null && dispatcher != null) SinkConfiguration(
+            renderer,
+            dispatcher
+        )
         else null
     }
 }

--- a/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
@@ -18,8 +18,8 @@
 
 package io.klogging.config
 
+import io.klogging.Level
 import io.klogging.dispatching.DispatchString
-import io.klogging.events.Level
 import io.klogging.rendering.RenderString
 
 /**

--- a/src/commonMain/kotlin/io/klogging/config/LoggingConfig.kt
+++ b/src/commonMain/kotlin/io/klogging/config/LoggingConfig.kt
@@ -18,7 +18,7 @@
 
 package io.klogging.config
 
-import io.klogging.events.Level
+import io.klogging.Level
 import io.klogging.internal.warn
 
 /**

--- a/src/commonMain/kotlin/io/klogging/dispatching/Dispatcher.kt
+++ b/src/commonMain/kotlin/io/klogging/dispatching/Dispatcher.kt
@@ -18,9 +18,9 @@
 
 package io.klogging.dispatching
 
+import io.klogging.Level
 import io.klogging.config.KloggingConfiguration
 import io.klogging.config.SinkConfiguration
-import io.klogging.events.Level
 import io.klogging.events.LogEvent
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch

--- a/src/commonMain/kotlin/io/klogging/events/LogEvent.kt
+++ b/src/commonMain/kotlin/io/klogging/events/LogEvent.kt
@@ -18,6 +18,7 @@
 
 package io.klogging.events
 
+import io.klogging.Level
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 

--- a/src/commonMain/kotlin/io/klogging/impl/Common.kt
+++ b/src/commonMain/kotlin/io/klogging/impl/Common.kt
@@ -19,7 +19,7 @@
 package io.klogging.impl
 
 import io.klogging.BaseLogger
-import io.klogging.events.Level
+import io.klogging.Level
 import io.klogging.events.LogEvent
 import io.klogging.events.currentContext
 import kotlinx.datetime.Clock

--- a/src/commonMain/kotlin/io/klogging/impl/KloggerImpl.kt
+++ b/src/commonMain/kotlin/io/klogging/impl/KloggerImpl.kt
@@ -19,9 +19,9 @@
 package io.klogging.impl
 
 import io.klogging.Klogger
+import io.klogging.Level
 import io.klogging.Logging
 import io.klogging.context.LogContext
-import io.klogging.events.Level
 import io.klogging.events.LogEvent
 import io.klogging.events.currentContext
 import io.klogging.template.templateItems

--- a/src/commonMain/kotlin/io/klogging/impl/KloggerImpl.kt
+++ b/src/commonMain/kotlin/io/klogging/impl/KloggerImpl.kt
@@ -20,7 +20,6 @@ package io.klogging.impl
 
 import io.klogging.Klogger
 import io.klogging.Level
-import io.klogging.Logging
 import io.klogging.context.LogContext
 import io.klogging.events.LogEvent
 import io.klogging.events.currentContext

--- a/src/commonMain/kotlin/io/klogging/impl/Logging.kt
+++ b/src/commonMain/kotlin/io/klogging/impl/Logging.kt
@@ -16,7 +16,7 @@
 
 */
 
-package io.klogging
+package io.klogging.impl
 
 import io.klogging.dispatching.Dispatcher.dispatchEvent
 import io.klogging.events.LogEvent

--- a/src/commonMain/kotlin/io/klogging/impl/NoCoLoggerImpl.kt
+++ b/src/commonMain/kotlin/io/klogging/impl/NoCoLoggerImpl.kt
@@ -19,7 +19,6 @@
 package io.klogging.impl
 
 import io.klogging.Level
-import io.klogging.Logging
 import io.klogging.NoCoLogger
 import io.klogging.events.LogEvent
 import io.klogging.template.templateItems

--- a/src/commonMain/kotlin/io/klogging/impl/NoCoLoggerImpl.kt
+++ b/src/commonMain/kotlin/io/klogging/impl/NoCoLoggerImpl.kt
@@ -18,9 +18,9 @@
 
 package io.klogging.impl
 
+import io.klogging.Level
 import io.klogging.Logging
 import io.klogging.NoCoLogger
-import io.klogging.events.Level
 import io.klogging.events.LogEvent
 import io.klogging.template.templateItems
 import kotlinx.coroutines.CoroutineScope

--- a/src/commonMain/kotlin/io/klogging/internal/InternalLogging.kt
+++ b/src/commonMain/kotlin/io/klogging/internal/InternalLogging.kt
@@ -18,9 +18,9 @@
 
 package io.klogging.internal
 
+import io.klogging.Level
 import io.klogging.dispatching.STDERR
 import io.klogging.dispatching.STDOUT
-import io.klogging.events.Level
 import io.klogging.events.LogEvent
 import io.klogging.rendering.RenderString
 import io.klogging.rendering.localString
@@ -35,7 +35,12 @@ internal val RENDER_INTERNAL: RenderString = { e: LogEvent ->
  * Simplified internal logging for Klogging diagnostics, especially during
  * configuration.
  */
-public fun log(loggerName: String, level: Level, message: String, exception: Exception? = null) {
+public fun log(
+    loggerName: String,
+    level: Level,
+    message: String,
+    exception: Exception? = null
+) {
     val event = LogEvent(
         logger = loggerName,
         level = level,
@@ -46,18 +51,34 @@ public fun log(loggerName: String, level: Level, message: String, exception: Exc
     else STDERR(RENDER_INTERNAL(event))
 }
 
-public fun debug(loggerName: String, message: String, exception: Exception? = null) {
+public fun debug(
+    loggerName: String,
+    message: String,
+    exception: Exception? = null
+) {
     log(loggerName, Level.DEBUG, message, exception)
 }
 
-public fun info(loggerName: String, message: String, exception: Exception? = null) {
+public fun info(
+    loggerName: String,
+    message: String,
+    exception: Exception? = null
+) {
     log(loggerName, Level.INFO, message, exception)
 }
 
-public fun warn(loggerName: String, message: String, exception: Exception? = null) {
+public fun warn(
+    loggerName: String,
+    message: String,
+    exception: Exception? = null
+) {
     log(loggerName, Level.WARN, message, exception)
 }
 
-public fun error(loggerName: String, message: String, exception: Exception? = null) {
+public fun error(
+    loggerName: String,
+    message: String,
+    exception: Exception? = null
+) {
     log(loggerName, Level.ERROR, message, exception)
 }

--- a/src/commonMain/kotlin/io/klogging/rendering/RenderGelf.kt
+++ b/src/commonMain/kotlin/io/klogging/rendering/RenderGelf.kt
@@ -18,7 +18,7 @@
 
 package io.klogging.rendering
 
-import io.klogging.events.Level
+import io.klogging.Level
 import io.klogging.events.LogEvent
 import kotlinx.datetime.Instant
 

--- a/src/jvmTest/kotlin/io/klogging/Helpers.kt
+++ b/src/jvmTest/kotlin/io/klogging/Helpers.kt
@@ -20,7 +20,6 @@ package io.klogging
 
 import io.klogging.config.SinkConfiguration
 import io.klogging.config.loggingConfiguration
-import io.klogging.events.Level
 import io.klogging.events.LogEvent
 import io.klogging.events.hostname
 import io.klogging.rendering.RenderString

--- a/src/jvmTest/kotlin/io/klogging/KloggerTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/KloggerTest.kt
@@ -18,7 +18,6 @@
 
 package io.klogging
 
-import io.klogging.events.Level
 import io.klogging.events.LogEvent
 import io.klogging.events.hostname
 import io.klogging.template.templateItems

--- a/src/jvmTest/kotlin/io/klogging/LevelsTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/LevelsTest.kt
@@ -18,7 +18,6 @@
 
 package io.klogging
 
-import io.klogging.events.Level
 import io.klogging.events.LogEvent
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe

--- a/src/jvmTest/kotlin/io/klogging/Playpen.kt
+++ b/src/jvmTest/kotlin/io/klogging/Playpen.kt
@@ -22,7 +22,6 @@ import io.klogging.config.loggingConfiguration
 import io.klogging.config.seq
 import io.klogging.context.logContext
 import io.klogging.dispatching.STDOUT
-import io.klogging.events.Level
 import io.klogging.rendering.RENDER_SIMPLE
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch

--- a/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
@@ -18,8 +18,8 @@
 
 package io.klogging.config
 
+import io.klogging.Level
 import io.klogging.dispatching.STDOUT
-import io.klogging.events.Level
 import io.klogging.rendering.RENDER_SIMPLE
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactly

--- a/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
@@ -18,10 +18,10 @@
 
 package io.klogging.config
 
+import io.klogging.Level
 import io.klogging.config.KloggingConfiguration.minimumLevelOf
 import io.klogging.dispatching.STDERR
 import io.klogging.dispatching.STDOUT
-import io.klogging.events.Level
 import io.klogging.randomLevel
 import io.klogging.randomString
 import io.klogging.rendering.RENDER_CLEF

--- a/src/jvmTest/kotlin/io/klogging/dispatching/DispatcherTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/dispatching/DispatcherTest.kt
@@ -18,10 +18,10 @@
 
 package io.klogging.dispatching
 
+import io.klogging.Level
 import io.klogging.config.KloggingConfiguration
 import io.klogging.config.defaultConsole
 import io.klogging.config.loggingConfiguration
-import io.klogging.events.Level
 import io.klogging.randomLevel
 import io.klogging.randomString
 import io.klogging.rendering.RENDER_SIMPLE

--- a/src/jvmTest/kotlin/io/klogging/impl/KtLoggerImplTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/impl/KtLoggerImplTest.kt
@@ -18,7 +18,7 @@
 
 package io.klogging.impl
 
-import io.klogging.events.Level
+import io.klogging.Level
 import io.klogging.logEvent
 import io.klogging.logger
 import io.klogging.randomString

--- a/src/jvmTest/kotlin/io/klogging/rendering/RenderClefTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/rendering/RenderClefTest.kt
@@ -18,7 +18,7 @@
 
 package io.klogging.rendering
 
-import io.klogging.events.Level
+import io.klogging.Level
 import io.klogging.events.LogEvent
 import io.klogging.events.currentContext
 import io.klogging.randomString

--- a/src/jvmTest/kotlin/io/klogging/rendering/RenderGelfTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/rendering/RenderGelfTest.kt
@@ -18,7 +18,7 @@
 
 package io.klogging.rendering
 
-import io.klogging.events.Level
+import io.klogging.Level
 import io.klogging.events.LogEvent
 import io.klogging.randomString
 import io.klogging.timestampNow

--- a/src/jvmTest/kotlin/io/klogging/rendering/RenderSimpleTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/rendering/RenderSimpleTest.kt
@@ -18,7 +18,7 @@
 
 package io.klogging.rendering
 
-import io.klogging.events.Level
+import io.klogging.Level
 import io.klogging.events.LogEvent
 import io.klogging.randomString
 import io.klogging.timestampNow


### PR DESCRIPTION
1. `Level` is a first-class concern throughout Klogging: Move it to a top-level package namespace
2. `Logging` is an implementation class: Demote it to a "lower" package namespace

This PR does not address the naming of the `Logging` class.  Its name implies a top-level concern rather than its actual place in  internal implementation.