### PR TITLE
Formatting, hygiene, idiomacy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[**]
+end_of_line = lf
+max_line_length = 100
+
+[*.{kt, kts}]
+# Oh, the irony.  IntelliJ insists on sorting java* imports last
+disabled_rules = import-ordering

--- a/src/commonMain/kotlin/io/klogging/config/Defaults.kt
+++ b/src/commonMain/kotlin/io/klogging/config/Defaults.kt
@@ -22,11 +22,11 @@ import io.klogging.Level.INFO
 import io.klogging.dispatching.STDOUT
 import io.klogging.rendering.RENDER_SIMPLE
 
-/** Simple sink configuration for rendering simple strings to STDOUT. */
+/** Simple sink configuration for rendering simple strings to the standard output stream. */
 public val STDOUT_SIMPLE: SinkConfiguration =
     SinkConfiguration(RENDER_SIMPLE, STDOUT)
 
-/** Simple default configuration for logging to the "console" sink. */
+/** Simple default configuration for logging to the standard output stream. */
 public val defaultConsole: KloggingConfiguration.() -> Unit = {
     sink("console", STDOUT_SIMPLE)
     logging { fromMinLevel(INFO) { toSink("console") } }

--- a/src/commonMain/kotlin/io/klogging/config/Defaults.kt
+++ b/src/commonMain/kotlin/io/klogging/config/Defaults.kt
@@ -18,15 +18,16 @@
 
 package io.klogging.config
 
-import io.klogging.Level
+import io.klogging.Level.INFO
 import io.klogging.dispatching.STDOUT
 import io.klogging.rendering.RENDER_SIMPLE
 
-/** Simple sink configuration for rendering simple strings to the standard output stream. */
-public val STDOUT_SIMPLE: SinkConfiguration = SinkConfiguration(RENDER_SIMPLE, STDOUT)
+/** Simple sink configuration for rendering simple strings to STDOUT. */
+public val STDOUT_SIMPLE: SinkConfiguration =
+    SinkConfiguration(RENDER_SIMPLE, STDOUT)
 
-/** Simple default configuration for logging to the console. */
+/** Simple default configuration for logging to the "console" sink. */
 public val defaultConsole: KloggingConfiguration.() -> Unit = {
     sink("console", STDOUT_SIMPLE)
-    logging { fromMinLevel(Level.INFO) { toSink("console") } }
+    logging { fromMinLevel(INFO) { toSink("console") } }
 }

--- a/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
@@ -32,9 +32,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
-/**
- * Data class for JSON representation of [KloggingConfiguration].
- */
+/** Data class for JSON representation of [KloggingConfiguration]. */
 @Serializable
 public data class JsonConfiguration(
     val append: Boolean = false,
@@ -42,9 +40,7 @@ public data class JsonConfiguration(
     val logging: List<JsonLoggingConfig>,
 )
 
-/**
- * Data class for JSON representation of a [SinkConfiguration].
- */
+/** Data class for JSON representation of a [SinkConfiguration]. */
 @Serializable
 public data class JsonSinkConfiguration(
     val renderWith: String?,
@@ -58,9 +54,7 @@ public data class JsonSinkConfiguration(
     }
 }
 
-/**
- * Data class for JSON representation of a [LoggingConfig].
- */
+/** Data class for JSON representation of a [LoggingConfig]. */
 @Serializable
 public data class JsonLoggingConfig(
     val fromLoggerBase: String? = null,
@@ -79,9 +73,7 @@ public data class JsonLoggingConfig(
     }
 }
 
-/**
- * Data class for JSON representation of a [LevelRange].
- */
+/** Data class for JSON representation of a [LevelRange]. */
 @Serializable
 public data class JsonLevelRange(
     val fromMinLevel: Level? = null,
@@ -100,11 +92,11 @@ public data class JsonLevelRange(
 }
 
 /**
- * Read configuration from JSON into a [JsonConfiguration] object.
+ * Reads configuration from JSON into a [JsonConfiguration] object.
  *
- * @param configJson JSON containing Klogging configuration.
+ * @param configJson JSON containing Klogging configuration
  *
- * @return an object used to configure Klogging.
+ * @return an object for Klogging configuration
  */
 internal fun readConfig(configJson: String): JsonConfiguration? =
     try {
@@ -114,26 +106,22 @@ internal fun readConfig(configJson: String): JsonConfiguration? =
         null
     }
 
-/**
- * Load [KloggingConfiguration] from JSON configuration string.
- */
+/** Loads [KloggingConfiguration] from JSON configuration string. */
 internal fun configureFromJson(configJson: String) {
-    readConfig(configJson)?.let { config ->
-        if (!config.append) KloggingConfiguration.reset()
-        config.sinks.forEach { entry ->
-            entry.value.toSinkConfiguration()?.let {
-                KloggingConfiguration.sinks[entry.key] = it
+    readConfig(configJson)?.let { (append, sinks, logging) ->
+        if (!append) KloggingConfiguration.reset()
+        sinks.forEach { (key, value) ->
+            value.toSinkConfiguration()?.let {
+                KloggingConfiguration.sinks[key] = it
             }
         }
-        config.logging.forEach { logging ->
-            KloggingConfiguration.configs.add(logging.toLoggingConfig())
+        logging.forEach {
+            KloggingConfiguration.configs.add(it.toLoggingConfig())
         }
     }
 }
 
-/**
- * Map of built-in renderers by name.
- */
+/** Map of built-in renderers by name. */
 internal val BUILT_IN_RENDERERS: Map<String, RenderString> by lazy {
     mapOf(
         "RENDER_SIMPLE" to RENDER_SIMPLE,
@@ -142,9 +130,7 @@ internal val BUILT_IN_RENDERERS: Map<String, RenderString> by lazy {
     )
 }
 
-/**
- * Map of built-in dispatchers by name.
- */
+/** Map of built-in dispatchers by name. */
 internal val BUILT_IN_DISPATCHERS: Map<String, DispatchString> by lazy {
     mapOf(
         "STDOUT" to STDOUT,

--- a/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
@@ -53,10 +53,7 @@ public data class JsonSinkConfiguration(
     internal fun toSinkConfiguration(): SinkConfiguration? {
         val renderer = BUILT_IN_RENDERERS[renderWith]
         val dispatcher = BUILT_IN_DISPATCHERS[dispatchTo]
-        return if (renderer != null && dispatcher != null) SinkConfiguration(
-            renderer,
-            dispatcher
-        )
+        return if (renderer != null && dispatcher != null) SinkConfiguration(renderer, dispatcher)
         else null
     }
 }

--- a/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
@@ -43,17 +43,11 @@ public data class JsonConfiguration(
 
 /** Data class for JSON representation of a [SinkConfiguration]. */
 @Serializable
-public data class JsonSinkConfiguration(
-    val renderWith: String?,
-    val dispatchTo: String?,
-) {
+public data class JsonSinkConfiguration(val renderWith: String?, val dispatchTo: String?) {
     internal fun toSinkConfiguration(): SinkConfiguration? {
         val renderer = BUILT_IN_RENDERERS[renderWith]
         val dispatcher = BUILT_IN_DISPATCHERS[dispatchTo]
-        return if (renderer != null && dispatcher != null) SinkConfiguration(
-            renderer,
-            dispatcher
-        )
+        return if (renderer != null && dispatcher != null) SinkConfiguration(renderer, dispatcher)
         else null
     }
 }

--- a/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
@@ -115,14 +115,14 @@ internal fun readConfig(configJson: String): JsonConfiguration? =
 
 /** Load [KloggingConfiguration] from JSON configuration string. */
 public fun configureFromJson(configJson: String) {
-    readConfig(configJson)?.let { (append, kloggingLevel, sinks, logging) ->
+    readConfig(configJson)?.let { (append, kloggingMinLogLevel, sinks, logging) ->
         info("Reading JSON configuration") // TODO: move this logging into reading from file with name
         if (!append) KloggingConfiguration.reset()
-        if (kloggingLevel != null) kloggingMinLogLevel = kloggingLevel
-        sinks.forEach { entry ->
-            entry.value.toSinkConfiguration()?.let {
-                debug("Setting sink `${entry.key}` with ${entry.value}")
-                KloggingConfiguration.sinks[entry.key] = it
+        if (kloggingMinLogLevel != null) threadKloggingMinLogLevel = kloggingMinLogLevel
+        sinks.forEach { (key, value) ->
+            value.toSinkConfiguration()?.let {
+                debug("Setting sink `$key` with $value")
+                KloggingConfiguration.sinks[key] = it
             }
         }
         logging.forEach {

--- a/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
@@ -115,10 +115,10 @@ internal fun readConfig(configJson: String): JsonConfiguration? =
 
 /** Load [KloggingConfiguration] from JSON configuration string. */
 public fun configureFromJson(configJson: String) {
-    readConfig(configJson)?.let { (append, kloggingMinLogLevel, sinks, logging) ->
+    readConfig(configJson)?.let { (append, configKloggingMinLogLevel, sinks, logging) ->
         info("Reading JSON configuration") // TODO: move this logging into reading from file with name
         if (!append) KloggingConfiguration.reset()
-        if (kloggingMinLogLevel != null) threadKloggingMinLogLevel = kloggingMinLogLevel
+        if (configKloggingMinLogLevel != null) kloggingMinLogLevel = configKloggingMinLogLevel
         sinks.forEach { (key, value) ->
             value.toSinkConfiguration()?.let {
                 debug("Setting sink `$key` with $value")

--- a/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
@@ -35,7 +35,7 @@ internal val defaultKloggingMinLogLevel: Level = try {
 } catch (ex: Exception) { INFO }
 
 @ThreadLocal
-internal var threadKloggingMinLogLevel: Level = defaultKloggingMinLogLevel
+internal var kloggingMinLogLevel: Level = defaultKloggingMinLogLevel
 
 /**
  * Root DSL function for creating a [KloggingConfiguration].
@@ -63,7 +63,7 @@ public object KloggingConfiguration {
      */
     @ConfigDsl
     public fun kloggingMinLevel(minLevel: Level) {
-        threadKloggingMinLogLevel = minLevel
+        kloggingMinLogLevel = minLevel
     }
 
     /**
@@ -107,7 +107,7 @@ public object KloggingConfiguration {
 
     /** Clear all configurations and reset default Klogging log level. */
     internal fun reset() {
-        threadKloggingMinLogLevel = defaultKloggingMinLogLevel
+        kloggingMinLogLevel = defaultKloggingMinLogLevel
         sinks.clear()
         configs.clear()
     }

--- a/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
@@ -35,7 +35,7 @@ internal val defaultKloggingMinLogLevel: Level = try {
 } catch (ex: Exception) { INFO }
 
 @ThreadLocal
-internal var kloggingMinLogLevel: Level = defaultKloggingMinLogLevel
+internal var threadKloggingMinLogLevel: Level = defaultKloggingMinLogLevel
 
 /**
  * Root DSL function for creating a [KloggingConfiguration].
@@ -63,7 +63,7 @@ public object KloggingConfiguration {
      */
     @ConfigDsl
     public fun kloggingMinLevel(minLevel: Level) {
-        kloggingMinLogLevel = minLevel
+        threadKloggingMinLogLevel = minLevel
     }
 
     /**
@@ -107,7 +107,7 @@ public object KloggingConfiguration {
 
     /** Clear all configurations and reset default Klogging log level. */
     internal fun reset() {
-        kloggingMinLogLevel = defaultKloggingMinLogLevel
+        threadKloggingMinLogLevel = defaultKloggingMinLogLevel
         sinks.clear()
         configs.clear()
     }

--- a/src/commonMain/kotlin/io/klogging/internal/InternalLogging.kt
+++ b/src/commonMain/kotlin/io/klogging/internal/InternalLogging.kt
@@ -23,7 +23,7 @@ import io.klogging.Level.DEBUG
 import io.klogging.Level.ERROR
 import io.klogging.Level.INFO
 import io.klogging.Level.WARN
-import io.klogging.config.kloggingMinLogLevel
+import io.klogging.config.threadKloggingMinLogLevel
 import io.klogging.dispatching.STDERR
 import io.klogging.dispatching.STDOUT
 import io.klogging.events.LogEvent
@@ -47,7 +47,7 @@ public fun log(
     message: String,
     exception: Exception? = null
 ) {
-    if (level < kloggingMinLogLevel) return
+    if (level < threadKloggingMinLogLevel) return
     val event = LogEvent(
         logger = KLOGGING_LOGGER,
         level = level,

--- a/src/commonMain/kotlin/io/klogging/internal/InternalLogging.kt
+++ b/src/commonMain/kotlin/io/klogging/internal/InternalLogging.kt
@@ -23,7 +23,7 @@ import io.klogging.Level.DEBUG
 import io.klogging.Level.ERROR
 import io.klogging.Level.INFO
 import io.klogging.Level.WARN
-import io.klogging.config.threadKloggingMinLogLevel
+import io.klogging.config.kloggingMinLogLevel
 import io.klogging.dispatching.STDERR
 import io.klogging.dispatching.STDOUT
 import io.klogging.events.LogEvent
@@ -47,7 +47,7 @@ public fun log(
     message: String,
     exception: Exception? = null
 ) {
-    if (level < threadKloggingMinLogLevel) return
+    if (level < kloggingMinLogLevel) return
     val event = LogEvent(
         logger = KLOGGING_LOGGER,
         level = level,

--- a/src/commonMain/kotlin/io/klogging/rendering/RenderSimple.kt
+++ b/src/commonMain/kotlin/io/klogging/rendering/RenderSimple.kt
@@ -18,7 +18,6 @@
 
 package io.klogging.rendering
 
-import io.klogging.events.LogEvent
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -26,20 +25,21 @@ import kotlinx.datetime.toLocalDateTime
 /**
  * Extension property for Kotlin [Instant] to render it in local time as two words.
  *
- * The simple mechanism is to render as ISO8601 and replace the `T` with a space.
+ * The simple mechanism is to render as ISO8601 and replace the first `T`
+ * with a space.
  */
 public val Instant.localString: String
     get() = toLocalDateTime(TimeZone.currentSystemDefault())
         .toString()
-        .replace('T', ' ')
+        .replaceFirst('T', ' ')
 
 /**
  * Simple implementation of [RenderString] for output to a console, mostly on one line.
  *
  * If there is a stack trace it is on second and following lines.
  */
-public val RENDER_SIMPLE: RenderString = { e: LogEvent ->
-    "${e.timestamp.localString} ${e.level} [${e.context}] ${e.logger} : ${e.message}" +
-        if (e.items.isNotEmpty()) " : ${e.items}" else "" +
-            if (e.stackTrace != null) "\n${e.stackTrace}" else ""
+public val RENDER_SIMPLE: RenderString = {
+    "${it.timestamp.localString} ${it.level} [${it.context}] ${it.logger} : ${it.message}" +
+        if (it.items.isNotEmpty()) " : ${it.items}"
+        else "" + if (it.stackTrace != null) "\n${it.stackTrace}" else ""
 }

--- a/src/commonMain/kotlin/io/klogging/rendering/RenderSimple.kt
+++ b/src/commonMain/kotlin/io/klogging/rendering/RenderSimple.kt
@@ -18,6 +18,7 @@
 
 package io.klogging.rendering
 
+import io.klogging.events.LogEvent
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -25,8 +26,7 @@ import kotlinx.datetime.toLocalDateTime
 /**
  * Extension property for Kotlin [Instant] to render it in local time as two words.
  *
- * The simple mechanism is to render as ISO8601 and replace the first `T`
- * with a space.
+ * The simple mechanism is to render as ISO8601 and replace the `T` with a space.
  */
 public val Instant.localString: String
     get() = toLocalDateTime(TimeZone.currentSystemDefault())
@@ -38,8 +38,8 @@ public val Instant.localString: String
  *
  * If there is a stack trace it is on second and following lines.
  */
-public val RENDER_SIMPLE: RenderString = {
-    "${it.timestamp.localString} ${it.level} [${it.context}] ${it.logger} : ${it.message}" +
-        if (it.items.isNotEmpty()) " : ${it.items}"
-        else "" + if (it.stackTrace != null) "\n${it.stackTrace}" else ""
+public val RENDER_SIMPLE: RenderString = { e: LogEvent ->
+    "${e.timestamp.localString} ${e.level} [${e.context}] ${e.logger} : ${e.message}" +
+        if (e.items.isNotEmpty()) " : ${e.items}" else "" +
+            if (e.stackTrace != null) "\n${e.stackTrace}" else ""
 }

--- a/src/commonMain/kotlin/io/klogging/rendering/RenderSimple.kt
+++ b/src/commonMain/kotlin/io/klogging/rendering/RenderSimple.kt
@@ -34,7 +34,8 @@ public val Instant.localString: String
         .replace('T', ' ')
 
 /**
- * Simple implementation of [RenderString] for output to a console, mostly on one line.
+ * Simple implementation of [RenderString] for output to the standard output stream, mostly on one
+ * line.
  *
  * If there is a stack trace it is on second and following lines.
  */

--- a/src/commonMain/kotlin/io/klogging/rendering/RenderSimple.kt
+++ b/src/commonMain/kotlin/io/klogging/rendering/RenderSimple.kt
@@ -31,7 +31,7 @@ import kotlinx.datetime.toLocalDateTime
 public val Instant.localString: String
     get() = toLocalDateTime(TimeZone.currentSystemDefault())
         .toString()
-        .replaceFirst('T', ' ')
+        .replace('T', ' ')
 
 /**
  * Simple implementation of [RenderString] for output to a console, mostly on one line.

--- a/src/jvmTest/kotlin/io/klogging/Playpen.kt
+++ b/src/jvmTest/kotlin/io/klogging/Playpen.kt
@@ -27,13 +27,12 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.util.UUID
+import java.util.UUID.randomUUID
 
 /**
  * Main program for experimenting with Klogging features as they are developed.
  */
 suspend fun main() = coroutineScope {
-
     loggingConfiguration {
         sink("stdout", RENDER_SIMPLE, STDOUT)
         sink("seq", seq("http://localhost:5341"))
@@ -47,7 +46,7 @@ suspend fun main() = coroutineScope {
     }
 
     val logger = logger("Playpen")
-    launch(logContext("run" to UUID.randomUUID())) {
+    launch(logContext("run" to randomUUID())) {
         logger.info { "Start" }
         repeat(2) { c ->
             logger.info { e(">> {Counter}", c + 1) }

--- a/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
@@ -123,13 +123,13 @@ internal class JsonConfigurationTest : DescribeSpec({
             it("is not changed if not set in JSON") {
                 configureFromJson("""{}""")
 
-                kloggingMinLogLevel shouldBe INFO
+                threadKloggingMinLogLevel shouldBe INFO
             }
             it("is changed if set in JSON") {
-                kloggingMinLogLevel = INFO
+                threadKloggingMinLogLevel = INFO
                 configureFromJson("""{"kloggingMinLogLevel":"DEBUG"}""")
 
-                kloggingMinLogLevel shouldBe DEBUG
+                threadKloggingMinLogLevel shouldBe DEBUG
             }
         }
     }

--- a/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
@@ -123,13 +123,13 @@ internal class JsonConfigurationTest : DescribeSpec({
             it("is not changed if not set in JSON") {
                 configureFromJson("""{}""")
 
-                threadKloggingMinLogLevel shouldBe INFO
+                kloggingMinLogLevel shouldBe INFO
             }
             it("is changed if set in JSON") {
-                threadKloggingMinLogLevel = INFO
+                kloggingMinLogLevel = INFO
                 configureFromJson("""{"kloggingMinLogLevel":"DEBUG"}""")
 
-                threadKloggingMinLogLevel shouldBe DEBUG
+                kloggingMinLogLevel shouldBe DEBUG
             }
         }
     }

--- a/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
@@ -28,7 +28,7 @@ import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
-class JsonConfigurationTest : DescribeSpec({
+internal class JsonConfigurationTest : DescribeSpec({
     describe("Configuration from JSON") {
         describe("simple configuration using built-in renderers and dispatchers") {
             val simpleJsonConfig = """

--- a/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
@@ -35,8 +35,7 @@ import io.kotest.matchers.maps.shouldContain
 import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.shouldBe
 
-class KloggingConfigurationTest : DescribeSpec({
-
+internal class KloggingConfigurationTest : DescribeSpec({
     beforeTest {
         KloggingConfiguration.reset()
     }

--- a/src/jvmTest/kotlin/io/klogging/dispatching/DispatcherTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/dispatching/DispatcherTest.kt
@@ -29,8 +29,8 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 
-class DispatcherTest : DescribeSpec({
-
+internal class DispatcherTest : DescribeSpec({
+    /** @todo Why reset each test?  This is a smell around use of globals */
     beforeTest {
         KloggingConfiguration.reset()
     }

--- a/src/jvmTest/kotlin/io/klogging/dispatching/DispatcherTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/dispatching/DispatcherTest.kt
@@ -19,7 +19,6 @@
 package io.klogging.dispatching
 
 import io.klogging.Level
-import io.klogging.config.KloggingConfiguration
 import io.klogging.config.defaultConsole
 import io.klogging.config.loggingConfiguration
 import io.klogging.randomLevel
@@ -30,11 +29,6 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 
 internal class DispatcherTest : DescribeSpec({
-    /** @todo Why reset each test?  This is a smell around use of globals */
-    beforeTest {
-        KloggingConfiguration.reset()
-    }
-
     describe("sinksFor() function") {
         describe("when no loggers are configured") {
             it("returns no sinks") {


### PR DESCRIPTION
PR description _underneath_, after I first explain something.

**NOTE**: Upstream/main did not compile (see undefined var `kloggingLogLevel`).  As part of merging in upstream to my PR, I assumed this should have been `kloggingMinLogLevel` (a global).  A test failed after I changed this.  Examining the test, I was more confident in my change, but then found the JSON serialization was broken: I also renamed to `kloggingMinLogLevel` the field in the JCON configuration class that was `kloggingLogLevel` so that JSON would find a 1-to-1 correspondence in naming.  I assume this was just a spot missed by commit 248cb0d6aaa2b8304db22706645de89c8f877b41

```
            it("is changed if set in JSON") {
                kloggingMinLogLevel = INFO
                configureFromJson("""{"kloggingMinLogLevel":"DEBUG"}""")

                kloggingMinLogLevel shouldBe DEBUG
            }
```

**FYI** -- Next PR after this from me is to add `.editorconfig` and 100-character line limits.  I'm working through my queue of commits off a `next` branch in my repo, so I don't push commits on top of the current PR on the `main` branch.

----

1. IntelliJ reformatted and I accepted
2. Documentation on single line when it formats that way
3. Static imports where an explicitness is not required
4. Destructuring in lambdas where suggested and it clarified the code
5. Use of implicit `it`

Adding an extra line after class declarations before the first member
declaration is a style choice to discuss.
