### PR TITLE
More hygiene and consistency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,11 @@ kotlin {
             }
         }
         val commonTest by getting
-        val jvmMain by getting
+        val jvmMain by getting {
+            dependencies {
+                implementation(kotlin("reflect"))
+            }
+        }
         val jvmTest by getting {
             dependencies {
                 implementation("io.kotest:kotest-runner-junit5:$kotestVersion")

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -37,13 +37,13 @@ loggingConfiguration {
         // Log everything from `com.example` base.
         fromLoggerBase("com.example")
         // INFO level only.
-        atLevel(Level.INFO) {
+        atLevel(INFO) {
             // To both standard out and Seq.
             toSink("stdout")
             toSink("seq")
         }
         // WARN level and above (more severe).
-        fromMinLevel(Level.WARN) {
+        fromMinLevel(WARN) {
             // To both standard error and Seq.
             toSink("stderr")
             toSink("seq")
@@ -149,7 +149,7 @@ is written to the console and the configuration is ignored.
 An example:
 
 ```kotlin
-    fromMinLevel(Level.INFO) {
+    fromMinLevel(INFO) {
         toSink("console")
         toSink("seq")
     }
@@ -160,11 +160,11 @@ During dispatching, an event is never dispatched to a sink more than once. Given
 ```kotlin
     logging {
         fromLoggerBase("com.example")
-        fromMinLevel(Level.INFO) {
+        fromMinLevel(INFO) {
             toSink("stdout")
             toSink("seq")
         }
-        fromMinLevel(Level.WARN) {
+        fromMinLevel(WARN) {
             toSink("stderr")
             toSink("seq")
         }

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -19,6 +19,8 @@ In no particular order at this stage.
   than Seq. Consider library reuse rather than internal implementation.
 - Consider service loader discovery or similar patterns for 3rd-party
   integrations such as SLF4J so users only pull in relevant dependencies.
+- Consider turning `KloggingConfiguration` from a global singleton into a class and a default
+  function to return a common, shared instance.
 
 ## Additions to the library
 

--- a/src/commonMain/kotlin/io/klogging/NoCoLogger.kt
+++ b/src/commonMain/kotlin/io/klogging/NoCoLogger.kt
@@ -18,6 +18,12 @@
 
 package io.klogging
 
+import io.klogging.Level.DEBUG
+import io.klogging.Level.ERROR
+import io.klogging.Level.FATAL
+import io.klogging.Level.INFO
+import io.klogging.Level.TRACE
+import io.klogging.Level.WARN
 import io.klogging.events.LogEvent
 
 /**
@@ -40,44 +46,44 @@ public interface NoCoLogger : BaseLogger {
         if (values.isEmpty()) emitEvent(level, null, template)
         else emitEvent(level, null, e(template, *values))
 
-    public fun trace(event: Any?): Unit = log(Level.TRACE, event)
-    public fun debug(event: Any?): Unit = log(Level.DEBUG, event)
-    public fun info(event: Any?): Unit = log(Level.INFO, event)
-    public fun warn(event: Any?): Unit = log(Level.WARN, event)
-    public fun error(event: Any?): Unit = log(Level.ERROR, event)
-    public fun fatal(event: Any?): Unit = log(Level.FATAL, event)
+    public fun trace(event: Any?): Unit = log(TRACE, event)
+    public fun debug(event: Any?): Unit = log(DEBUG, event)
+    public fun info(event: Any?): Unit = log(INFO, event)
+    public fun warn(event: Any?): Unit = log(WARN, event)
+    public fun error(event: Any?): Unit = log(ERROR, event)
+    public fun fatal(event: Any?): Unit = log(FATAL, event)
 
-    public fun trace(template: String, vararg values: Any?): Unit = log(Level.TRACE, template, *values)
-    public fun debug(template: String, vararg values: Any?): Unit = log(Level.DEBUG, template, *values)
-    public fun info(template: String, vararg values: Any?): Unit = log(Level.INFO, template, *values)
-    public fun warn(template: String, vararg values: Any?): Unit = log(Level.WARN, template, *values)
-    public fun error(template: String, vararg values: Any?): Unit = log(Level.ERROR, template, *values)
-    public fun fatal(template: String, vararg values: Any?): Unit = log(Level.FATAL, template, *values)
+    public fun trace(template: String, vararg values: Any?): Unit = log(TRACE, template, *values)
+    public fun debug(template: String, vararg values: Any?): Unit = log(DEBUG, template, *values)
+    public fun info(template: String, vararg values: Any?): Unit = log(INFO, template, *values)
+    public fun warn(template: String, vararg values: Any?): Unit = log(WARN, template, *values)
+    public fun error(template: String, vararg values: Any?): Unit = log(ERROR, template, *values)
+    public fun fatal(template: String, vararg values: Any?): Unit = log(FATAL, template, *values)
 
-    public fun trace(exception: Exception, event: Any?): Unit = log(Level.TRACE, exception, event)
-    public fun debug(exception: Exception, event: Any?): Unit = log(Level.DEBUG, exception, event)
-    public fun info(exception: Exception, event: Any?): Unit = log(Level.INFO, exception, event)
-    public fun warn(exception: Exception, event: Any?): Unit = log(Level.WARN, exception, event)
-    public fun error(exception: Exception, event: Any?): Unit = log(Level.ERROR, exception, event)
-    public fun fatal(exception: Exception, event: Any?): Unit = log(Level.FATAL, exception, event)
+    public fun trace(exception: Exception, event: Any?): Unit = log(TRACE, exception, event)
+    public fun debug(exception: Exception, event: Any?): Unit = log(DEBUG, exception, event)
+    public fun info(exception: Exception, event: Any?): Unit = log(INFO, exception, event)
+    public fun warn(exception: Exception, event: Any?): Unit = log(WARN, exception, event)
+    public fun error(exception: Exception, event: Any?): Unit = log(ERROR, exception, event)
+    public fun fatal(exception: Exception, event: Any?): Unit = log(FATAL, exception, event)
 
     public fun trace(exception: Exception, template: String, vararg values: Any?): Unit =
-        log(Level.TRACE, exception, template, *values)
+        log(TRACE, exception, template, *values)
 
     public fun debug(exception: Exception, template: String, vararg values: Any?): Unit =
-        log(Level.DEBUG, exception, template, *values)
+        log(DEBUG, exception, template, *values)
 
     public fun info(exception: Exception, template: String, vararg values: Any?): Unit =
-        log(Level.INFO, exception, template, *values)
+        log(INFO, exception, template, *values)
 
     public fun warn(exception: Exception, template: String, vararg values: Any?): Unit =
-        log(Level.WARN, exception, template, *values)
+        log(WARN, exception, template, *values)
 
     public fun error(exception: Exception, template: String, vararg values: Any?): Unit =
-        log(Level.ERROR, exception, template, *values)
+        log(ERROR, exception, template, *values)
 
     public fun fatal(exception: Exception, template: String, vararg values: Any?): Unit =
-        log(Level.FATAL, exception, template, *values)
+        log(FATAL, exception, template, *values)
 
     public fun log(level: Level, exception: Exception, event: NoCoLogger.() -> Any?) {
         if (isLevelEnabled(level)) emitEvent(level, exception, event())
@@ -87,19 +93,19 @@ public interface NoCoLogger : BaseLogger {
         if (isLevelEnabled(level)) emitEvent(level, null, event())
     }
 
-    public fun trace(event: NoCoLogger.() -> Any?): Unit = log(Level.TRACE, event)
-    public fun debug(event: NoCoLogger.() -> Any?): Unit = log(Level.DEBUG, event)
-    public fun info(event: NoCoLogger.() -> Any?): Unit = log(Level.INFO, event)
-    public fun warn(event: NoCoLogger.() -> Any?): Unit = log(Level.WARN, event)
-    public fun error(event: NoCoLogger.() -> Any?): Unit = log(Level.ERROR, event)
-    public fun fatal(event: NoCoLogger.() -> Any?): Unit = log(Level.FATAL, event)
+    public fun trace(event: NoCoLogger.() -> Any?): Unit = log(TRACE, event)
+    public fun debug(event: NoCoLogger.() -> Any?): Unit = log(DEBUG, event)
+    public fun info(event: NoCoLogger.() -> Any?): Unit = log(INFO, event)
+    public fun warn(event: NoCoLogger.() -> Any?): Unit = log(WARN, event)
+    public fun error(event: NoCoLogger.() -> Any?): Unit = log(ERROR, event)
+    public fun fatal(event: NoCoLogger.() -> Any?): Unit = log(FATAL, event)
 
-    public fun trace(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(Level.TRACE, exception, event)
-    public fun debug(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(Level.DEBUG, exception, event)
-    public fun info(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(Level.INFO, exception, event)
-    public fun warn(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(Level.WARN, exception, event)
-    public fun error(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(Level.ERROR, exception, event)
-    public fun fatal(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(Level.FATAL, exception, event)
+    public fun trace(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(TRACE, exception, event)
+    public fun debug(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(DEBUG, exception, event)
+    public fun info(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(INFO, exception, event)
+    public fun warn(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(WARN, exception, event)
+    public fun error(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(ERROR, exception, event)
+    public fun fatal(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(FATAL, exception, event)
 
     /**
      * Evaluates a message template with the supplied values, returning [LogEvent].

--- a/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/JsonConfiguration.kt
@@ -19,6 +19,8 @@
 package io.klogging.config
 
 import io.klogging.Level
+import io.klogging.Level.FATAL
+import io.klogging.Level.TRACE
 import io.klogging.internal.debug
 import io.klogging.internal.warn
 import kotlinx.serialization.Serializable
@@ -82,9 +84,9 @@ public data class JsonLevelRange(
         val range = when {
             // `atLevel` has priority over `fromMinLevel`
             atLevel != null -> LevelRange(atLevel, atLevel)
-            fromMinLevel != null -> LevelRange(fromMinLevel, Level.FATAL)
+            fromMinLevel != null -> LevelRange(fromMinLevel, FATAL)
             // All levels
-            else -> LevelRange(Level.TRACE, Level.FATAL)
+            else -> LevelRange(TRACE, FATAL)
         }
         range.sinkNames.addAll(toSinks)
         return range

--- a/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
@@ -34,6 +34,22 @@ internal val defaultKloggingMinLogLevel: Level = try {
     getenv(ENV_KLOGGING_MIN_LOG_LEVEL)?.let { Level.valueOf(it) } ?: INFO
 } catch (ex: Exception) { INFO }
 
+/**
+ * As a general rule, global thread locals are a strong anti-pattern.  They make testing difficult
+ * and fragile, make reproducing production issues additionally challenging, impede programmer
+ * understanding and comprehension of control flow, and lead to various smells in architecture.
+ * They tend to be a source of subtle bugs both in the library, and in caller misuse.
+ *
+ * See kdoc for [ThreadLocal]:
+ * ```
+ * The annotation has effect only in Kotlin/Native platform.
+ * PLEASE NOTE THAT THIS ANNOTATION MAY GO AWAY IN UPCOMING RELEASES.
+ * ```
+ *
+ * @todo Replace with a better mechanism such as an instance object.  For simple usage in a typical
+ *       program, this should be "invisible".  For more complex programs, other mechanisms would
+ *       support caller's choice of logging context including varying minimum log levels
+ */
 @ThreadLocal
 internal var kloggingMinLogLevel: Level = defaultKloggingMinLogLevel
 

--- a/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
+++ b/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
@@ -51,7 +51,8 @@ public fun loggingConfiguration(append: Boolean = false, block: KloggingConfigur
 }
 
 /**
- * Klogging configuration for a runtime.
+ * Klogging configuration for a runtime.  This is a global singleton.  No function or property is
+ * thread-safe.
  */
 public object KloggingConfiguration {
 

--- a/src/commonMain/kotlin/io/klogging/config/LoggingConfig.kt
+++ b/src/commonMain/kotlin/io/klogging/config/LoggingConfig.kt
@@ -19,6 +19,8 @@
 package io.klogging.config
 
 import io.klogging.Level
+import io.klogging.Level.FATAL
+import io.klogging.Level.TRACE
 import io.klogging.internal.warn
 
 /**
@@ -87,7 +89,7 @@ public class LoggingConfig {
         minLevel: Level,
         configBlock: LevelRange.() -> Unit
     ) {
-        val range = LevelRange(minLevel, Level.FATAL)
+        val range = LevelRange(minLevel, FATAL)
         range.apply(configBlock)
         if (range.sinkNames.isNotEmpty()) ranges.add(range)
     }
@@ -112,7 +114,7 @@ public class LoggingConfig {
      */
     @ConfigDsl
     public fun toSink(sinkName: String) {
-        val range = LevelRange(Level.TRACE, Level.FATAL)
+        val range = LevelRange(TRACE, FATAL)
         range.toSink(sinkName)
         if (range.sinkNames.isNotEmpty()) ranges.add(range)
     }

--- a/src/commonMain/kotlin/io/klogging/rendering/RenderGelf.kt
+++ b/src/commonMain/kotlin/io/klogging/rendering/RenderGelf.kt
@@ -19,6 +19,13 @@
 package io.klogging.rendering
 
 import io.klogging.Level
+import io.klogging.Level.DEBUG
+import io.klogging.Level.ERROR
+import io.klogging.Level.FATAL
+import io.klogging.Level.INFO
+import io.klogging.Level.NONE
+import io.klogging.Level.TRACE
+import io.klogging.Level.WARN
 import io.klogging.events.LogEvent
 import kotlinx.datetime.Instant
 
@@ -63,11 +70,11 @@ public fun Instant.graylogFormat(): String {
  * 0=Emergency,1=Alert,2=Critical,3=Error,4=Warning,5=Notice,6=Informational,7=Debug
  */
 public fun graylogLevel(level: Level): Int = when (level) {
-    Level.NONE -> 7
-    Level.TRACE -> 7
-    Level.DEBUG -> 7
-    Level.INFO -> 6
-    Level.WARN -> 4
-    Level.ERROR -> 3
-    Level.FATAL -> 2
+    NONE -> 7
+    TRACE -> 7
+    DEBUG -> 7
+    INFO -> 6
+    WARN -> 4
+    ERROR -> 3
+    FATAL -> 2
 }

--- a/src/jvmMain/kotlin/io/klogging/classNameOf.kt
+++ b/src/jvmMain/kotlin/io/klogging/classNameOf.kt
@@ -20,7 +20,10 @@ package io.klogging
 
 import kotlin.reflect.KClass
 
-public actual fun classNameOf(ownerClass: KClass<*>): String? {
-    val ownerName = ownerClass.java.name
-    return if (ownerName.endsWith("\$Companion")) ownerName.substringBeforeLast('$') else ownerName
-}
+/**
+ * Notes:
+ * 1. The companion class can have a different name than "$Companion"
+ * 2. Kotlin reflection is only supported for JVM, not for JS
+ */
+public actual fun classNameOf(ownerClass: KClass<*>): String? =
+    if (ownerClass.isCompanion) ownerClass.java.enclosingClass.name else ownerClass.java.name

--- a/src/jvmTest/kotlin/io/klogging/Helpers.kt
+++ b/src/jvmTest/kotlin/io/klogging/Helpers.kt
@@ -18,6 +18,7 @@
 
 package io.klogging
 
+import io.klogging.Level.TRACE
 import io.klogging.config.SinkConfiguration
 import io.klogging.config.loggingConfiguration
 import io.klogging.events.LogEvent
@@ -62,7 +63,7 @@ fun savedEvents(): MutableList<LogEvent> {
     val saveEventRenderer: RenderString = { e -> saved.add(e); "" }
     loggingConfiguration {
         sink("test", SinkConfiguration(saveEventRenderer) {})
-        logging { fromMinLevel(Level.TRACE) { toSink("test") } }
+        logging { fromMinLevel(TRACE) { toSink("test") } }
     }
     return saved
 }

--- a/src/jvmTest/kotlin/io/klogging/KloggerTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/KloggerTest.kt
@@ -18,6 +18,11 @@
 
 package io.klogging
 
+import io.klogging.Level.DEBUG
+import io.klogging.Level.INFO
+import io.klogging.Level.NONE
+import io.klogging.Level.TRACE
+import io.klogging.Level.WARN
 import io.klogging.events.LogEvent
 import io.klogging.events.hostname
 import io.klogging.template.templateItems
@@ -27,7 +32,7 @@ import io.kotest.matchers.shouldBe
 import java.time.Instant
 
 class TestLogger(
-    private val minLevel: Level = Level.TRACE
+    private val minLevel: Level = TRACE
 ) : Klogger {
 
     override val name: String = "TestLogger"
@@ -43,7 +48,7 @@ class TestLogger(
 
     override suspend fun e(template: String, vararg values: Any?): LogEvent =
         LogEvent(
-            randomString(), timestampNow(), hostname, "TestLogger", Thread.currentThread().name, Level.NONE,
+            randomString(), timestampNow(), hostname, "TestLogger", Thread.currentThread().name, NONE,
             template, template, null, templateItems(template, *values).mapValues { e -> e.value.toString() }
         )
 }
@@ -57,7 +62,7 @@ class KloggerTest : DescribeSpec({
             it("logs a string message") {
                 val message = randomString()
                 with(TestLogger()) {
-                    log(Level.INFO, message)
+                    log(INFO, message)
                     logged shouldBe message
                 }
             }
@@ -65,7 +70,7 @@ class KloggerTest : DescribeSpec({
                 val message = randomString()
                 val exception = TestException(randomString())
                 with(TestLogger()) {
-                    log(Level.WARN, exception, message)
+                    log(WARN, exception, message)
                     except shouldBe exception
                     logged shouldBe message
                 }
@@ -89,7 +94,7 @@ class KloggerTest : DescribeSpec({
             it("logs an object") {
                 val thing = Instant.now()
                 with(TestLogger()) {
-                    log(Level.DEBUG, thing)
+                    log(DEBUG, thing)
                     logged shouldBe thing
                 }
             }
@@ -97,7 +102,7 @@ class KloggerTest : DescribeSpec({
                 val thing = listOf(randomString(), randomString())
                 val exception = TestException(randomString())
                 with(TestLogger()) {
-                    log(Level.WARN, exception, thing)
+                    log(WARN, exception, thing)
                     except shouldBe exception
                     logged shouldBe thing
                 }

--- a/src/jvmTest/kotlin/io/klogging/KloggingTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/KloggingTest.kt
@@ -32,6 +32,10 @@ class KloggingTest : DescribeSpec({
         it("is the full name of the class when its companion object implements Klogging") {
             ClassWithImplementingCompanion.logger.name shouldBe "io.klogging.ClassWithImplementingCompanion"
         }
+        it("is the full name of the class when its named companion object implements Klogging") {
+            ClassWithNamedImplementingCompanion.logger.name shouldBe "io.klogging.ClassWithNamedImplementingCompanion"
+        }
+        // TODO: Pathological case of an inner class named "Companion"
         it("is the full name of the class that creates a property using the logger() function") {
             ClassWithLoggerProperty().logger.name shouldBe "io.klogging.ClassWithLoggerProperty"
         }
@@ -45,6 +49,10 @@ class ImplementingClass : Klogging
 
 class ClassWithImplementingCompanion {
     companion object : Klogging
+}
+
+class ClassWithNamedImplementingCompanion {
+    companion object NamedCompanion : Klogging
 }
 
 class ClassWithLoggerProperty {

--- a/src/jvmTest/kotlin/io/klogging/Playpen.kt
+++ b/src/jvmTest/kotlin/io/klogging/Playpen.kt
@@ -18,6 +18,7 @@
 
 package io.klogging
 
+import io.klogging.Level.INFO
 import io.klogging.config.loggingConfiguration
 import io.klogging.config.seq
 import io.klogging.context.logContext
@@ -40,7 +41,7 @@ suspend fun main() = coroutineScope {
         logging {
             exactLogger("Playpen")
             toSink("seq")
-            fromMinLevel(Level.INFO) {
+            fromMinLevel(INFO) {
                 toSink("stdout")
             }
         }

--- a/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
@@ -18,7 +18,11 @@
 
 package io.klogging.config
 
-import io.klogging.Level
+import io.klogging.Level.DEBUG
+import io.klogging.Level.FATAL
+import io.klogging.Level.INFO
+import io.klogging.Level.NONE
+import io.klogging.Level.WARN
 import io.klogging.config.KloggingConfiguration.minimumLevelOf
 import io.klogging.dispatching.STDERR
 import io.klogging.dispatching.STDOUT
@@ -80,7 +84,7 @@ internal class KloggingConfigurationTest : DescribeSpec({
                     logging {
                         sink("console", STDOUT_SIMPLE)
                         fromLoggerBase("com.example")
-                        fromMinLevel(Level.INFO) {
+                        fromMinLevel(INFO) {
                             toSink("console")
                             toSink("logstash")
                         }
@@ -105,13 +109,13 @@ internal class KloggingConfigurationTest : DescribeSpec({
                         // Log everything from `com.example` base.
                         fromLoggerBase("com.example")
                         // INFO level only.
-                        atLevel(Level.INFO) {
+                        atLevel(INFO) {
                             // To both standard out and Seq.
                             toSink("stdout")
                             toSink("seq")
                         }
                         // WARN level and above (more severe).
-                        fromMinLevel(Level.WARN) {
+                        fromMinLevel(WARN) {
                             // To both standard error and Seq.
                             toSink("stderr")
                             toSink("seq")
@@ -121,7 +125,7 @@ internal class KloggingConfigurationTest : DescribeSpec({
                         // Exact logger name (e.g. one class).
                         exactLogger("com.example.service.FancyService")
                         // Log from DEBUG to Seq.
-                        fromMinLevel(Level.DEBUG) { toSink("seq") }
+                        fromMinLevel(DEBUG) { toSink("seq") }
                     }
                 }
 
@@ -135,13 +139,13 @@ internal class KloggingConfigurationTest : DescribeSpec({
                     with(configs.first()) {
                         nameMatch shouldBe Regex("^com.example.*")
                         ranges shouldHaveSize 2
-                        ranges.first() shouldBe LevelRange(Level.INFO, Level.INFO)
+                        ranges.first() shouldBe LevelRange(INFO, INFO)
                         with(ranges.first()) {
                             sinkNames shouldHaveSize 2
                             sinkNames.first() shouldBe "stdout"
                             sinkNames.last() shouldBe "seq"
                         }
-                        ranges.last() shouldBe LevelRange(Level.WARN, Level.FATAL)
+                        ranges.last() shouldBe LevelRange(WARN, FATAL)
                         with(ranges.last()) {
                             sinkNames shouldHaveSize 2
                             sinkNames.first() shouldBe "stderr"
@@ -151,7 +155,7 @@ internal class KloggingConfigurationTest : DescribeSpec({
                     with(configs.last()) {
                         nameMatch shouldBe Regex("^com.example.service.FancyService\$")
                         ranges shouldHaveSize 1
-                        ranges.first() shouldBe LevelRange(Level.DEBUG, Level.FATAL)
+                        ranges.first() shouldBe LevelRange(DEBUG, FATAL)
                         with(ranges.first()) {
                             sinkNames shouldHaveSize 1
                             sinkNames.first() shouldBe "seq"
@@ -165,7 +169,7 @@ internal class KloggingConfigurationTest : DescribeSpec({
                     sink("stderr", RENDER_SIMPLE, STDERR)
                     logging {
                         exactLogger("Test")
-                        atLevel(Level.WARN) { toSink("stderr") }
+                        atLevel(WARN) { toSink("stderr") }
                     }
                 }
 
@@ -179,11 +183,11 @@ internal class KloggingConfigurationTest : DescribeSpec({
             beforeTest { KloggingConfiguration.reset() }
 
             it("returns NONE if there is no configuration") {
-                minimumLevelOf(randomString()) shouldBe Level.NONE
+                minimumLevelOf(randomString()) shouldBe NONE
             }
             it("returns INFO from the default console configuration") {
                 loggingConfiguration { defaultConsole() }
-                minimumLevelOf(randomString()) shouldBe Level.INFO
+                minimumLevelOf(randomString()) shouldBe INFO
             }
             it("returns the level of a single configuration that matches the logger name") {
                 val name = randomString()
@@ -202,20 +206,20 @@ internal class KloggingConfigurationTest : DescribeSpec({
                 val name = randomString()
                 loggingConfiguration {
                     sink("stdout", RENDER_SIMPLE, STDOUT)
-                    logging { atLevel(Level.WARN) { toSink("stdout") } }
-                    logging { exactLogger(name); atLevel(Level.INFO) { toSink("stdout") } }
+                    logging { atLevel(WARN) { toSink("stdout") } }
+                    logging { exactLogger(name); atLevel(INFO) { toSink("stdout") } }
                 }
 
-                minimumLevelOf(name) shouldBe Level.INFO
+                minimumLevelOf(name) shouldBe INFO
             }
             it("returns NONE if no configurations match the event name") {
                 val name = randomString()
                 loggingConfiguration {
                     sink("stdout", RENDER_SIMPLE, STDOUT)
-                    logging { exactLogger(name); atLevel(Level.INFO) { toSink("stdout") } }
+                    logging { exactLogger(name); atLevel(INFO) { toSink("stdout") } }
                 }
 
-                minimumLevelOf(randomString()) shouldBe Level.NONE
+                minimumLevelOf(randomString()) shouldBe NONE
             }
         }
     }

--- a/src/jvmTest/kotlin/io/klogging/dispatching/DispatcherTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/dispatching/DispatcherTest.kt
@@ -18,7 +18,11 @@
 
 package io.klogging.dispatching
 
-import io.klogging.Level
+import io.klogging.Level.DEBUG
+import io.klogging.Level.ERROR
+import io.klogging.Level.INFO
+import io.klogging.Level.TRACE
+import io.klogging.Level.WARN
 import io.klogging.config.defaultConsole
 import io.klogging.config.loggingConfiguration
 import io.klogging.randomLevel
@@ -38,7 +42,7 @@ internal class DispatcherTest : DescribeSpec({
         describe("with default console configuration") {
             it("returns the sink for INFO") {
                 loggingConfiguration { defaultConsole() }
-                val sinks = Dispatcher.sinksFor(randomString(), Level.INFO)
+                val sinks = Dispatcher.sinksFor(randomString(), INFO)
 
                 sinks shouldHaveSize 1
                 sinks.first().dispatcher shouldBe STDOUT
@@ -46,7 +50,7 @@ internal class DispatcherTest : DescribeSpec({
             }
             it("returns no sinks for DEBUG") {
                 loggingConfiguration { defaultConsole() }
-                Dispatcher.sinksFor(randomString(), Level.DEBUG) shouldHaveSize 0
+                Dispatcher.sinksFor(randomString(), DEBUG) shouldHaveSize 0
             }
         }
         describe("with base logger name configuration") {
@@ -55,18 +59,18 @@ internal class DispatcherTest : DescribeSpec({
                     sink("console", RENDER_SIMPLE, STDOUT)
                     logging {
                         fromLoggerBase("com.example.Thing")
-                        fromMinLevel(Level.DEBUG) { toSink("console") }
+                        fromMinLevel(DEBUG) { toSink("console") }
                     }
                 }
             }
             it("returns no sinks when the logger name is different to the configuration name") {
-                Dispatcher.sinksFor(randomString(), Level.DEBUG) shouldHaveSize 0
+                Dispatcher.sinksFor(randomString(), DEBUG) shouldHaveSize 0
             }
             it("returns the sink when the logger name matches the configuration name exactly") {
-                Dispatcher.sinksFor("com.example.Thing", Level.INFO) shouldHaveSize 1
+                Dispatcher.sinksFor("com.example.Thing", INFO) shouldHaveSize 1
             }
             it("returns the sink when the logger name starts with the configuration name") {
-                Dispatcher.sinksFor("com.example.Thing\$Subclass", Level.WARN) shouldHaveSize 1
+                Dispatcher.sinksFor("com.example.Thing\$Subclass", WARN) shouldHaveSize 1
             }
         }
         describe("with exact logger name configuration") {
@@ -75,18 +79,18 @@ internal class DispatcherTest : DescribeSpec({
                     sink("console", RENDER_SIMPLE, STDOUT)
                     logging {
                         exactLogger("com.example.OtherThing")
-                        fromMinLevel(Level.DEBUG) { toSink("console") }
+                        fromMinLevel(DEBUG) { toSink("console") }
                     }
                 }
             }
             it("returns no sinks when the logger name is different to the configuration name") {
-                Dispatcher.sinksFor(randomString(), Level.DEBUG) shouldHaveSize 0
+                Dispatcher.sinksFor(randomString(), DEBUG) shouldHaveSize 0
             }
             it("returns the sink when the logger name matches the configuration name exactly") {
-                Dispatcher.sinksFor("com.example.OtherThing", Level.INFO) shouldHaveSize 1
+                Dispatcher.sinksFor("com.example.OtherThing", INFO) shouldHaveSize 1
             }
             it("returns the sink when the logger name starts with the configuration name") {
-                Dispatcher.sinksFor("com.example.OtherThing\$Subclass", Level.WARN) shouldHaveSize 0
+                Dispatcher.sinksFor("com.example.OtherThing\$Subclass", WARN) shouldHaveSize 0
             }
         }
         describe("with minimum level specification") {
@@ -95,7 +99,7 @@ internal class DispatcherTest : DescribeSpec({
                     sink("stdout", RENDER_SIMPLE, STDOUT)
                     sink("stderr", RENDER_SIMPLE, STDERR)
                     logging {
-                        fromMinLevel(Level.INFO) {
+                        fromMinLevel(INFO) {
                             toSink("stdout")
                             toSink("stderr")
                         }
@@ -103,13 +107,13 @@ internal class DispatcherTest : DescribeSpec({
                 }
             }
             it("returns no sinks when the level is below the configured level") {
-                Dispatcher.sinksFor(randomString(), Level.TRACE) shouldHaveSize 0
+                Dispatcher.sinksFor(randomString(), TRACE) shouldHaveSize 0
             }
             it("returns the sinks when the level is at the configured level") {
-                Dispatcher.sinksFor(randomString(), Level.INFO) shouldHaveSize 2
+                Dispatcher.sinksFor(randomString(), INFO) shouldHaveSize 2
             }
             it("returns the sinks when the level is above the configured level") {
-                Dispatcher.sinksFor(randomString(), Level.ERROR) shouldHaveSize 2
+                Dispatcher.sinksFor(randomString(), ERROR) shouldHaveSize 2
             }
         }
     }

--- a/src/jvmTest/kotlin/io/klogging/impl/KtLoggerImplTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/impl/KtLoggerImplTest.kt
@@ -18,7 +18,8 @@
 
 package io.klogging.impl
 
-import io.klogging.Level
+import io.klogging.Level.ERROR
+import io.klogging.Level.WARN
 import io.klogging.logEvent
 import io.klogging.logger
 import io.klogging.randomString
@@ -53,7 +54,7 @@ class KtLoggerImplTest : DescribeSpec({
                     timestamp shouldBe event.timestamp
                     host shouldBe event.host
                     logger shouldBe event.logger
-                    level shouldBe Level.WARN
+                    level shouldBe WARN
                     template shouldBe event.template
                     message shouldBe event.message
                     stackTrace shouldBe event.stackTrace
@@ -72,7 +73,7 @@ class KtLoggerImplTest : DescribeSpec({
                     timestamp shouldBe event.timestamp
                     host shouldBe event.host
                     logger shouldBe event.logger
-                    level shouldBe Level.ERROR
+                    level shouldBe ERROR
                     template shouldBe event.template
                     message shouldBe event.message
                     stackTrace shouldBe exception.stackTraceToString()

--- a/src/jvmTest/kotlin/io/klogging/rendering/RenderClefTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/rendering/RenderClefTest.kt
@@ -18,7 +18,7 @@
 
 package io.klogging.rendering
 
-import io.klogging.Level
+import io.klogging.Level.INFO
 import io.klogging.events.LogEvent
 import io.klogging.events.currentContext
 import io.klogging.randomString
@@ -31,7 +31,7 @@ class RenderClefTest : DescribeSpec({
         it("omits @x if `stackTrace` is null") {
             val ts = timestampNow()
             val event = LogEvent(
-                randomString(), ts, "test.local", "Test", currentContext(), Level.INFO,
+                randomString(), ts, "test.local", "Test", currentContext(), INFO,
                 null, "Message", null, mapOf()
             )
 
@@ -49,7 +49,7 @@ class RenderClefTest : DescribeSpec({
             val trace = randomString()
             val event =
                 LogEvent(
-                    randomString(), ts, "test.local", "Test", currentContext(), Level.INFO,
+                    randomString(), ts, "test.local", "Test", currentContext(), INFO,
                     null, "Message", trace, mapOf()
                 )
 
@@ -66,7 +66,7 @@ class RenderClefTest : DescribeSpec({
         it("includes @m but not @mt if `template` is null") {
             val ts = timestampNow()
             val event = LogEvent(
-                randomString(), ts, "test.local", "Test", currentContext(), Level.INFO,
+                randomString(), ts, "test.local", "Test", currentContext(), INFO,
                 null, "Message", null, mapOf()
             )
 
@@ -83,7 +83,7 @@ class RenderClefTest : DescribeSpec({
             val ts = timestampNow()
             val id = randomString()
             val event = LogEvent(
-                randomString(), ts, "test.local", "Test", currentContext(), Level.INFO,
+                randomString(), ts, "test.local", "Test", currentContext(), INFO,
                 "Id={Id}", "Id={Id}", null, mapOf("Id" to id)
             )
 
@@ -100,7 +100,7 @@ class RenderClefTest : DescribeSpec({
         it("omits context if the event `context` is null") {
             val ts = timestampNow()
             val event = LogEvent(
-                randomString(), ts, "test.local", "Test", null, Level.INFO,
+                randomString(), ts, "test.local", "Test", null, INFO,
                 null, "Message", null, mapOf()
             )
 

--- a/src/jvmTest/kotlin/io/klogging/rendering/RenderGelfTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/rendering/RenderGelfTest.kt
@@ -18,7 +18,7 @@
 
 package io.klogging.rendering
 
-import io.klogging.Level
+import io.klogging.Level.INFO
 import io.klogging.events.LogEvent
 import io.klogging.randomString
 import io.klogging.timestampNow
@@ -30,7 +30,7 @@ class RenderGelfTest : DescribeSpec({
         it("includes logger name as _logger") {
             val ts = timestampNow()
             val event = LogEvent(
-                randomString(), ts, "test.local", "Test", null, Level.INFO,
+                randomString(), ts, "test.local", "Test", null, INFO,
                 null, "Message", null, mapOf()
             )
 
@@ -39,7 +39,7 @@ class RenderGelfTest : DescribeSpec({
                 |"host":"${event.host}",
                 |"short_message":"${event.message}",
                 |"timestamp":${ts.graylogFormat()},
-                |"level":${graylogLevel(Level.INFO)},
+                |"level":${graylogLevel(INFO)},
                 |"_logger":"${event.logger}"
                 |}""".trimMargin().replace("\n", "")
         }
@@ -48,7 +48,7 @@ class RenderGelfTest : DescribeSpec({
         val ts = timestampNow()
         val trace = randomString()
         val event = LogEvent(
-            randomString(), ts, "test.local", "Test", null, Level.INFO,
+            randomString(), ts, "test.local", "Test", null, INFO,
             null, "Message", trace, mapOf()
         )
 
@@ -58,7 +58,7 @@ class RenderGelfTest : DescribeSpec({
                 |"short_message":"${event.message}",
                 |"full_message":"$trace",
                 |"timestamp":${ts.graylogFormat()},
-                |"level":${graylogLevel(Level.INFO)},
+                |"level":${graylogLevel(INFO)},
                 |"_logger":"${event.logger}"
                 |}""".trimMargin().replace("\n", "")
     }

--- a/src/jvmTest/kotlin/io/klogging/rendering/RenderSimpleTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/rendering/RenderSimpleTest.kt
@@ -18,7 +18,8 @@
 
 package io.klogging.rendering
 
-import io.klogging.Level
+import io.klogging.Level.INFO
+import io.klogging.Level.WARN
 import io.klogging.events.LogEvent
 import io.klogging.randomString
 import io.klogging.timestampNow
@@ -30,7 +31,7 @@ class RenderSimpleTest : DescribeSpec({
         it("omits null stack trace") {
             val ts = timestampNow()
             val event = LogEvent(
-                randomString(), ts, "test.local", "Test", "test-thread", Level.INFO,
+                randomString(), ts, "test.local", "Test", "test-thread", INFO,
                 null, "Message", null, mapOf()
             )
 
@@ -40,7 +41,7 @@ class RenderSimpleTest : DescribeSpec({
         it("includes items only if they are present") {
             val ts = timestampNow()
             val event = LogEvent(
-                randomString(), ts, "test.local", "Test", "test-thread", Level.WARN,
+                randomString(), ts, "test.local", "Test", "test-thread", WARN,
                 null, "Message", null, mapOf("colour" to "green")
             )
 
@@ -51,7 +52,7 @@ class RenderSimpleTest : DescribeSpec({
             val ts = timestampNow()
             val stackTrace = "${randomString()}\n${randomString()}\n${randomString()}"
             val event = LogEvent(
-                randomString(), ts, "test.local", "Test", "test-thread", Level.INFO,
+                randomString(), ts, "test.local", "Test", "test-thread", INFO,
                 null, "Message", stackTrace, mapOf()
             )
 


### PR DESCRIPTION
Commits:
- TODO noting issues with `kloggingMinLogLevel` <-- You may or may not want this one
- Full use of static imports for Level <-- now consistent in uses every place I could find. It looks big, but is just static imports
- Improve implementation; more idiomatic <-- More correct implementation of a helper function for JVM target
- Commentary on Klogging configuration <-- Just comments & kdoc