### PR TITLE
Fully migrate to kotlinx-datetime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ import io.klogging.build.configureSpotless
 import io.klogging.build.configureTesting
 import io.klogging.build.configureVersioning
 import io.klogging.build.configureWrapper
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompileCommon
 
 plugins {
     kotlin("multiplatform")
@@ -51,7 +52,9 @@ kotlin {
         withJava() // Needed for jacocoTestReport Gradle target
 
         compilations.all {
-            kotlinOptions.jvmTarget = "11"
+            kotlinOptions {
+                jvmTarget = "11"
+            }
         }
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -104,6 +107,14 @@ kotlin {
 // This might be a workaround for a bug in Gradle Kotlin scripts, see:
 // https://youtrack.jetbrains.com/issue/KT-46165
 tasks.withType<ProcessResources> { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+
+// TODO: Move this and above `explicitApi()` to a buildSrc configuration script
+tasks.withType<KotlinCompileCommon>().configureEach {
+    kotlinOptions {
+        // Opt in for kotlinx-datetime features (see `Timestamps.kt`)
+        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+    }
+}
 
 configureAssemble()
 configureJacoco(jacocoVersion)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -53,7 +53,7 @@ loggingConfiguration {
         // Exact logger name (e.g. one class).
         exactLogger("com.example.service.FancyService")
         // Log from DEBUG to Seq.
-        fromMinLevel(Level.DEBUG) { to Sink("seq") }
+        fromMinLevel(DEBUG) { to Sink("seq") }
     }
     logging {
         // Log all audit events.

--- a/src/commonMain/kotlin/io/klogging/NoCoLogger.kt
+++ b/src/commonMain/kotlin/io/klogging/NoCoLogger.kt
@@ -35,10 +35,17 @@ public interface NoCoLogger : BaseLogger {
 
     public fun emitEvent(level: Level, exception: Exception?, event: Any?)
 
-    public fun log(level: Level, exception: Exception, event: Any?): Unit = emitEvent(level, exception, event)
+    public fun log(level: Level, exception: Exception, event: Any?): Unit =
+        emitEvent(level, exception, event)
+
     public fun log(level: Level, event: Any?): Unit = emitEvent(level, null, event)
 
-    public fun log(level: Level, exception: Exception, template: String, vararg values: Any?): Unit =
+    public fun log(
+        level: Level,
+        exception: Exception,
+        template: String,
+        vararg values: Any?
+    ): Unit =
         if (values.isEmpty()) emitEvent(level, exception, template)
         else emitEvent(level, exception, e(template, *values))
 
@@ -100,12 +107,23 @@ public interface NoCoLogger : BaseLogger {
     public fun error(event: NoCoLogger.() -> Any?): Unit = log(ERROR, event)
     public fun fatal(event: NoCoLogger.() -> Any?): Unit = log(FATAL, event)
 
-    public fun trace(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(TRACE, exception, event)
-    public fun debug(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(DEBUG, exception, event)
-    public fun info(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(INFO, exception, event)
-    public fun warn(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(WARN, exception, event)
-    public fun error(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(ERROR, exception, event)
-    public fun fatal(exception: Exception, event: NoCoLogger.() -> Any?): Unit = log(FATAL, exception, event)
+    public fun trace(exception: Exception, event: NoCoLogger.() -> Any?): Unit =
+        log(TRACE, exception, event)
+
+    public fun debug(exception: Exception, event: NoCoLogger.() -> Any?): Unit =
+        log(DEBUG, exception, event)
+
+    public fun info(exception: Exception, event: NoCoLogger.() -> Any?): Unit =
+        log(INFO, exception, event)
+
+    public fun warn(exception: Exception, event: NoCoLogger.() -> Any?): Unit =
+        log(WARN, exception, event)
+
+    public fun error(exception: Exception, event: NoCoLogger.() -> Any?): Unit =
+        log(ERROR, exception, event)
+
+    public fun fatal(exception: Exception, event: NoCoLogger.() -> Any?): Unit =
+        log(FATAL, exception, event)
 
     /**
      * Evaluates a message template with the supplied values, returning [LogEvent].

--- a/src/commonMain/kotlin/io/klogging/Timestamps.kt
+++ b/src/commonMain/kotlin/io/klogging/Timestamps.kt
@@ -1,0 +1,31 @@
+/*
+
+   Copyright 2021 Michael Strasser.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package io.klogging
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+
+public fun timestampNow(): Instant = Clock.System.now()
+
+/** Shim for compatibility with JDK's `Instant` */
+@OptIn(ExperimentalTime::class)
+public fun Instant.minusSeconds(seconds: Long): Instant =
+    this - Duration.seconds(seconds)

--- a/src/commonMain/kotlin/io/klogging/config/Environment.kt
+++ b/src/commonMain/kotlin/io/klogging/config/Environment.kt
@@ -21,18 +21,19 @@ package io.klogging.config
 internal const val ENV_KLOGGING_MIN_LOG_LEVEL = "KLOGGING_MIN_LOG_LEVEL"
 internal const val ENV_KLOGGING_CONFIG_JSON_PATH = "KLOGGING_CONFIG_JSON_PATH"
 
+/**
+ * This function should be `private`, but as it is implemented in multiplatform, must be `internal`.
+ * Do not call this function directly outside this file.
+ *
+ * @see [ENV]
+ */
 internal expect fun getenv(): Map<String, String>
 
+/** A map of operating system environment variables and values for the current process. */
 internal val ENV: Map<String, String> by lazy { getenv() }
 
-/**
- * Return the value of an item in the running environment, or
- * `null` if the name is not found.
- */
+/** Returns the value of an item in the running environment, or `null` if the name is not found. */
 public fun getenv(name: String): String? = ENV[name]
 
-/**
- * Return the value of an item in the running environment, or
- * a default value if not found.
- */
+/** Returns the value of an item in the running environment, or a default value if not found. */
 public fun getenv(name: String, default: String): String = ENV[name] ?: default

--- a/src/commonMain/kotlin/io/klogging/config/LoggingConfig.kt
+++ b/src/commonMain/kotlin/io/klogging/config/LoggingConfig.kt
@@ -25,6 +25,9 @@ import io.klogging.internal.warn
 
 /**
  * Inclusive range of logging levels with the names of sinks where events will be dispatched.
+ *
+ * @todo Implement [ClosedRange] and get the benefits of stdlib support.  See
+ *       [Ranges](https://kotlinlang.org/docs/ranges.html)
  */
 public data class LevelRange(
     val minLevel: Level,

--- a/src/commonMain/kotlin/io/klogging/events/LogEvent.kt
+++ b/src/commonMain/kotlin/io/klogging/events/LogEvent.kt
@@ -33,6 +33,7 @@ public data class LogEvent(
      * Unique identifier for this event.
      *
      * @todo Why not a UUID?  Perhaps explanatory text on the rational for an unsigned long?
+     * @todo Better would be something like a DB's auto-incrementing integer.  See chat discussion
      */
     val id: String = Random.nextULong().toString(16),
     /** When the event occurred, to microsecond or better precision. */

--- a/src/commonMain/kotlin/io/klogging/events/LogEvent.kt
+++ b/src/commonMain/kotlin/io/klogging/events/LogEvent.kt
@@ -19,7 +19,7 @@
 package io.klogging.events
 
 import io.klogging.Level
-import kotlinx.datetime.Clock
+import io.klogging.timestampNow
 import kotlinx.datetime.Instant
 import kotlin.random.Random
 import kotlin.random.nextULong
@@ -29,10 +29,14 @@ import kotlin.random.nextULong
  * a program.
  */
 public data class LogEvent(
-    /** Unique identifier for this event. */
+    /**
+     * Unique identifier for this event.
+     *
+     * @todo Why not a UUID?  Perhaps explanatory text on the rational for an unsigned long?
+     */
     val id: String = Random.nextULong().toString(16),
     /** When the event occurred, to microsecond or better precision. */
-    val timestamp: Instant = Clock.System.now(),
+    val timestamp: Instant = timestampNow(),
     /** Host where the event occurred. */
     val host: String = hostname,
     /** Name of the logger that emitted the event. */

--- a/src/commonMain/kotlin/io/klogging/impl/Common.kt
+++ b/src/commonMain/kotlin/io/klogging/impl/Common.kt
@@ -22,7 +22,7 @@ import io.klogging.BaseLogger
 import io.klogging.Level
 import io.klogging.events.LogEvent
 import io.klogging.events.currentContext
-import kotlinx.datetime.Clock
+import io.klogging.timestampNow
 
 /**
  * Copy a [LogEvent], setting the level and the stack trace from any exception.
@@ -52,7 +52,7 @@ public fun BaseLogger.eventFrom(
         else -> {
             val (message, stackTrace) = messageAndStackTrace(eventObject, exception)
             LogEvent(
-                timestamp = Clock.System.now(),
+                timestamp = timestampNow(),
                 logger = this.name,
                 context = currentContext(),
                 level = level,

--- a/src/commonMain/kotlin/io/klogging/impl/KloggerImpl.kt
+++ b/src/commonMain/kotlin/io/klogging/impl/KloggerImpl.kt
@@ -24,7 +24,7 @@ import io.klogging.context.LogContext
 import io.klogging.events.LogEvent
 import io.klogging.events.currentContext
 import io.klogging.template.templateItems
-import kotlinx.datetime.Clock
+import io.klogging.timestampNow
 import kotlin.coroutines.coroutineContext
 
 public class KloggerImpl(
@@ -42,7 +42,7 @@ public class KloggerImpl(
     override suspend fun e(template: String, vararg values: Any?): LogEvent {
         val items = templateItems(template, *values).mapValues { e -> e.value.toString() }
         return LogEvent(
-            timestamp = Clock.System.now(),
+            timestamp = timestampNow(),
             logger = this.name,
             context = currentContext(),
             level = minLevel(),

--- a/src/commonMain/kotlin/io/klogging/impl/NoCoLoggerImpl.kt
+++ b/src/commonMain/kotlin/io/klogging/impl/NoCoLoggerImpl.kt
@@ -22,10 +22,10 @@ import io.klogging.Level
 import io.klogging.NoCoLogger
 import io.klogging.events.LogEvent
 import io.klogging.template.templateItems
+import io.klogging.timestampNow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
 
 public class NoCoLoggerImpl(
     override val name: String,
@@ -41,7 +41,7 @@ public class NoCoLoggerImpl(
     override fun e(template: String, vararg values: Any?): LogEvent {
         val items = templateItems(template, *values).mapValues { e -> e.value.toString() }
         return LogEvent(
-            timestamp = Clock.System.now(),
+            timestamp = timestampNow(),
             logger = this.name,
             level = minLevel(),
             template = template,

--- a/src/commonMain/kotlin/io/klogging/rendering/RenderGelf.kt
+++ b/src/commonMain/kotlin/io/klogging/rendering/RenderGelf.kt
@@ -68,6 +68,8 @@ public fun Instant.graylogFormat(): String {
  * Map [Level]s to syslog levels used by Graylog:
  *
  * 0=Emergency,1=Alert,2=Critical,3=Error,4=Warning,5=Notice,6=Informational,7=Debug
+ *
+ * See [syslog(7)](https://www.man7.org/linux/man-pages/man3/syslog.3.html)
  */
 public fun graylogLevel(level: Level): Int = when (level) {
     NONE -> 7
@@ -76,5 +78,5 @@ public fun graylogLevel(level: Level): Int = when (level) {
     INFO -> 6
     WARN -> 4
     ERROR -> 3
-    FATAL -> 2
+    FATAL -> 2 // TODO: Why "critical" and not "alert"?  Perhaps explanatory text in the kdoc?
 }

--- a/src/jvmTest/kotlin/io/klogging/Helpers.kt
+++ b/src/jvmTest/kotlin/io/klogging/Helpers.kt
@@ -25,17 +25,16 @@ import io.klogging.events.LogEvent
 import io.klogging.events.hostname
 import io.klogging.rendering.RenderString
 import kotlinx.coroutines.delay
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.random.Random
 import kotlin.random.nextULong
 
-fun timestampNow() = Clock.System.now()
-
+/**
+ * @todo It is poor test practice to use random inputs: failing tests are hard to repeat, and
+ *       become flaky tests instead, and debugging becomes a race against time and hardware bits
+ */
 fun randomLoggerName() = Random.nextInt().toString(16)
-
 fun randomString() = Random.nextULong().toString(16)
-
 fun randomLevel() = Level.values().random()
 
 fun logEvent(

--- a/src/jvmTest/kotlin/io/klogging/impl/KtLoggerImplTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/impl/KtLoggerImplTest.kt
@@ -24,12 +24,12 @@ import io.klogging.logEvent
 import io.klogging.logger
 import io.klogging.randomString
 import io.klogging.savedEvents
+import io.klogging.timestampNow
 import io.klogging.waitForDispatch
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.maps.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import java.time.Instant
 
 class KtLoggerImplTest : DescribeSpec({
     describe("KtLoggerImpl implementation of KtLogger") {
@@ -92,7 +92,7 @@ class KtLoggerImplTest : DescribeSpec({
             }
             it("logs the string representation of anything else in the message field") {
                 val events = savedEvents()
-                val event = Instant.now()
+                val event = timestampNow()
                 logger("KtLoggerImplTest").info(event)
                 waitForDispatch()
 


### PR DESCRIPTION
1. Centralize calls into `Timestamps.kt`
2. Enable experimental features needed for tests (_ie_, `minusSeconds`)

There are still build complaints.  I'm not certain if they are correct.
Testing on JS and Native targets is non-existent at this time.  But all
current tests build.  One way to validate this further would be adding
the `-Werror` flag to the kotlin compiler (fail build on warnings).