### PR TITLE
More idiomatic

### DIFF
--- a/src/commonMain/kotlin/io/klogging/Level.kt
+++ b/src/commonMain/kotlin/io/klogging/Level.kt
@@ -18,12 +18,53 @@
 
 package io.klogging
 
+import io.klogging.Level.DEBUG
+import io.klogging.Level.ERROR
+import io.klogging.Level.FATAL
+import io.klogging.Level.INFO
+import io.klogging.Level.NONE
+import io.klogging.Level.TRACE
+import io.klogging.Level.WARN
 import kotlinx.serialization.Serializable
 
 /**
- * Levels of logging severity: higher level means more severe.
+ * Levels of logging severity: higher ordinal values means greater severity.
+ *
+ * These levels are based on common JVM practice, such as
+ * [Log4j](https://github.com/apache/logging-log4j2/blob/master/log4j-api/src/main/java/org/apache/logging/log4j/Level.java)
+ * and
+ * [SLF4J](https://github.com/qos-ch/slf4j/blob/master/slf4j-api/src/main/java/org/slf4j/event/Level.java).
+ * Contrast with [syslog(2)](https://linux.die.net/man/2/syslog) levels used by such as
+ * UNIX/Linux and Graylog.
  */
 @Serializable
 public enum class Level {
     NONE, TRACE, DEBUG, INFO, WARN, ERROR, FATAL
 }
+
+/**
+ * Map [Level]s to syslog levels.  Used by other tooling such as Graylog.  The level values for
+ * syslog are:
+ * - 0 = Emergency (unused)
+ * - 1 = Alert (unused)
+ * - 2 = Critical (mapped to from [FATAL])
+ * - 3 = Error (mapped to from [ERROR])
+ * - 4 = Warning (mapped to from [WARN])
+ * - 5 = Notice (unused)
+ * - 6 = Informational (mapped to from [INFO])
+ * - 7 = Debug (mapped to from [NONE], [TRACE], and [DEBUG])
+ *
+ * See [syslog(2)](https://linux.die.net/man/2/syslog)
+ *
+ * @todo [NONE] should not map to syslog's Debug?  Perhaps return an `Int?`?
+ */
+public val Level.syslog: Int
+    get() = when (this) {
+        NONE -> 7
+        TRACE -> 7
+        DEBUG -> 7
+        INFO -> 6
+        WARN -> 4
+        ERROR -> 3
+        FATAL -> 2
+    }

--- a/src/commonMain/kotlin/io/klogging/rendering/RenderGelf.kt
+++ b/src/commonMain/kotlin/io/klogging/rendering/RenderGelf.kt
@@ -18,15 +18,8 @@
 
 package io.klogging.rendering
 
-import io.klogging.Level
-import io.klogging.Level.DEBUG
-import io.klogging.Level.ERROR
-import io.klogging.Level.FATAL
-import io.klogging.Level.INFO
-import io.klogging.Level.NONE
-import io.klogging.Level.TRACE
-import io.klogging.Level.WARN
 import io.klogging.events.LogEvent
+import io.klogging.syslog
 import kotlinx.datetime.Instant
 
 private const val GELF_TEMPLATE =
@@ -52,7 +45,7 @@ public val RENDER_GELF: RenderString = { e: LogEvent ->
         .replace("{{SHORT}}", e.message)
         .replace("{{EX}}", exception)
         .replace("{{TS}}", e.timestamp.graylogFormat())
-        .replace("{{LEVEL}}", graylogLevel(e.level).toString())
+        .replace("{{LEVEL}}", e.level.syslog.toString())
         .replace("{{ITEMS}}", itemsJson)
 }
 
@@ -62,21 +55,4 @@ private fun formatStackTrace(stackTrace: String) = STACK_TEMPLATE
 public fun Instant.graylogFormat(): String {
     val ns = "000000000$nanosecondsOfSecond"
     return "$epochSeconds.${ns.substring(ns.length - 9)}"
-}
-
-/**
- * Map [Level]s to syslog levels used by Graylog:
- *
- * 0=Emergency,1=Alert,2=Critical,3=Error,4=Warning,5=Notice,6=Informational,7=Debug
- *
- * See [syslog(7)](https://www.man7.org/linux/man-pages/man3/syslog.3.html)
- */
-public fun graylogLevel(level: Level): Int = when (level) {
-    NONE -> 7
-    TRACE -> 7
-    DEBUG -> 7
-    INFO -> 6
-    WARN -> 4
-    ERROR -> 3
-    FATAL -> 2
 }

--- a/src/jvmTest/kotlin/io/klogging/rendering/RenderGelfTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/rendering/RenderGelfTest.kt
@@ -22,6 +22,7 @@ import io.klogging.Level.INFO
 import io.klogging.events.LogEvent
 import io.klogging.events.timestampNow
 import io.klogging.randomString
+import io.klogging.syslog
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
@@ -39,7 +40,7 @@ class RenderGelfTest : DescribeSpec({
                 |"host":"${event.host}",
                 |"short_message":"${event.message}",
                 |"timestamp":${ts.graylogFormat()},
-                |"level":${graylogLevel(INFO)},
+                |"level":${INFO.syslog},
                 |"_logger":"${event.logger}"
                 |}""".trimMargin().replace("\n", "")
         }
@@ -58,7 +59,7 @@ class RenderGelfTest : DescribeSpec({
                 |"short_message":"${event.message}",
                 |"full_message":"$trace",
                 |"timestamp":${ts.graylogFormat()},
-                |"level":${graylogLevel(INFO)},
+                |"level":${INFO.syslog},
                 |"_logger":"${event.logger}"
                 |}""".trimMargin().replace("\n", "")
     }


### PR DESCRIPTION
1. `Level` should be more than just a placeholder for a name and ordinal
2. Name the property (previously function) to `syslog`.  Graylog was not the
   originator of this scheme, and syslog is more widely understood, and applicable to other logging systems

----

Being solo, I made the above refactorings.  Had you & I paired in person, I expect the result would look different.

Questions:

1. Would the `.syslog` property belong in `Level.kt`, or in in a Gelf-related file?  (I feel `RenderGelf.kt` is the wrong file -- the levels are not specific to rendering, but represent a mapping concept between logging systems.)  An example alternative file might be something such as `GelfMapping.kt`
2. Property _vs_ function.  I used a dynamic property on `Level`; I could see a function as preferred.  It depends on your style/taste

Overall, if this merge is too counter your tastes/preferences, I'd rather it be rejected with explanation, than us hash remotely through detail.