### PR TITLE
Testing for `NONE` log level

### DIFF
--- a/batect.yml
+++ b/batect.yml
@@ -22,25 +22,25 @@ tasks:
     description: Build the library.
     run:
       container: build-env
-      command: ./gradlew --no-daemon assemble
+      command: ./gradlew assemble
 
   check:
     description: Run the unit tests and static analysis tools.
     run:
       container: build-env
-      command: ./gradlew --no-daemon check
+      command: ./gradlew check
 
   continuousCheck:
     description: Run 'check' and then re-run when any code changes are detected.
     run:
       container: build-env
-      command: ./gradlew --no-daemon --continuous check
+      command: ./gradlew --continuous check
 
   spotlessApply:
     description: Fix code formatting issues identified by Spotless.
     run:
       container: build-env
-      command: ./gradlew --no-daemon spotlessApply
+      command: ./gradlew spotlessApply
 
   shell:
     description: Start a shell in the development environment.
@@ -52,19 +52,19 @@ tasks:
     description: Check for outdated dependencies.
     run:
       container: build-env
-      command: ./gradlew --no-daemon dependencyUpdates -Drevision=release
+      command: ./gradlew dependencyUpdates -Drevision=release
 
   generateCodeCoverageReport:
     description: Generate a code coverage report based on a previous test run.
     run:
       container: build-env
-      command: ./gradlew --no-daemon jacocoTestReport
+      command: ./gradlew jacocoTestReport
 
   publishRelease:
     description: Publish the library to Sonatype's Open Source Software Repository Hosting (OSSRH), which will be synced to Maven Central.
     run:
       container: build-env
-      command: ./gradlew --no-daemon publishRelease
+      command: ./gradlew publishRelease
       environment:
         OSSRH_USERNAME: $OSSRH_USERNAME
         OSSRH_PASSWORD: $OSSRH_PASSWORD
@@ -76,7 +76,7 @@ tasks:
     description: Publish the library to Sonatype's Open Source Software Repository Hosting (OSSRH), which will be synced to Maven Central.
     run:
       container: build-env
-      command: ./gradlew --no-daemon publishSnapshot
+      command: ./gradlew publishSnapshot
       environment:
         OSSRH_USERNAME: $OSSRH_USERNAME
         OSSRH_PASSWORD: $OSSRH_PASSWORD
@@ -88,7 +88,7 @@ tasks:
     description: Assemble the files that would be published to a repository.
     run:
       container: build-env
-      command: ./gradlew --no-daemon assembleRelease
+      command: ./gradlew assembleRelease
       environment:
         SIGNING_KEY_ID: $SIGNING_KEY_ID # Run `gpg -K` to get this, take last eight characters
         SIGNING_KEY: $SIGNING_KEY # Run `gpg --export-secret-keys <ID> | base64` to get this

--- a/batect.yml
+++ b/batect.yml
@@ -22,25 +22,25 @@ tasks:
     description: Build the library.
     run:
       container: build-env
-      command: ./gradlew assemble
+      command: ./gradlew --no-daemon assemble
 
   check:
     description: Run the unit tests and static analysis tools.
     run:
       container: build-env
-      command: ./gradlew check
+      command: ./gradlew --no-daemon check
 
   continuousCheck:
     description: Run 'check' and then re-run when any code changes are detected.
     run:
       container: build-env
-      command: ./gradlew --continuous check
+      command: ./gradlew --no-daemon --continuous check
 
   spotlessApply:
     description: Fix code formatting issues identified by Spotless.
     run:
       container: build-env
-      command: ./gradlew spotlessApply
+      command: ./gradlew --no-daemon spotlessApply
 
   shell:
     description: Start a shell in the development environment.
@@ -52,19 +52,19 @@ tasks:
     description: Check for outdated dependencies.
     run:
       container: build-env
-      command: ./gradlew dependencyUpdates -Drevision=release
+      command: ./gradlew --no-daemon dependencyUpdates -Drevision=release
 
   generateCodeCoverageReport:
     description: Generate a code coverage report based on a previous test run.
     run:
       container: build-env
-      command: ./gradlew jacocoTestReport
+      command: ./gradlew --no-daemon jacocoTestReport
 
   publishRelease:
     description: Publish the library to Sonatype's Open Source Software Repository Hosting (OSSRH), which will be synced to Maven Central.
     run:
       container: build-env
-      command: ./gradlew publishRelease
+      command: ./gradlew --no-daemon publishRelease
       environment:
         OSSRH_USERNAME: $OSSRH_USERNAME
         OSSRH_PASSWORD: $OSSRH_PASSWORD
@@ -76,7 +76,7 @@ tasks:
     description: Publish the library to Sonatype's Open Source Software Repository Hosting (OSSRH), which will be synced to Maven Central.
     run:
       container: build-env
-      command: ./gradlew publishSnapshot
+      command: ./gradlew --no-daemon publishSnapshot
       environment:
         OSSRH_USERNAME: $OSSRH_USERNAME
         OSSRH_PASSWORD: $OSSRH_PASSWORD
@@ -88,7 +88,7 @@ tasks:
     description: Assemble the files that would be published to a repository.
     run:
       container: build-env
-      command: ./gradlew assembleRelease
+      command: ./gradlew --no-daemon assembleRelease
       environment:
         SIGNING_KEY_ID: $SIGNING_KEY_ID # Run `gpg -K` to get this, take last eight characters
         SIGNING_KEY: $SIGNING_KEY # Run `gpg --export-secret-keys <ID> | base64` to get this

--- a/src/commonMain/kotlin/io/klogging/BaseLogger.kt
+++ b/src/commonMain/kotlin/io/klogging/BaseLogger.kt
@@ -46,7 +46,10 @@ public interface BaseLogger {
      * Check whether this logger will emit log events at the specified logging
      * level.
      */
-    public fun isLevelEnabled(level: Level): Boolean = NONE != level && minLevel() <= level
+    public fun isLevelEnabled(level: Level): Boolean = when {
+        NONE == level -> false
+        else -> minLevel() <= level
+    }
 
     /** Is this logger enabled to emit [TRACE] events? */
     public fun isTraceEnabled(): Boolean = isLevelEnabled(TRACE)

--- a/src/commonMain/kotlin/io/klogging/BaseLogger.kt
+++ b/src/commonMain/kotlin/io/klogging/BaseLogger.kt
@@ -22,6 +22,7 @@ import io.klogging.Level.DEBUG
 import io.klogging.Level.ERROR
 import io.klogging.Level.FATAL
 import io.klogging.Level.INFO
+import io.klogging.Level.NONE
 import io.klogging.Level.TRACE
 import io.klogging.Level.WARN
 import io.klogging.internal.KloggingState
@@ -45,7 +46,7 @@ public interface BaseLogger {
      * Check whether this logger will emit log events at the specified logging
      * level.
      */
-    public fun isLevelEnabled(level: Level): Boolean = minLevel() <= level
+    public fun isLevelEnabled(level: Level): Boolean = NONE != level && minLevel() <= level
 
     /** Is this logger enabled to emit [TRACE] events? */
     public fun isTraceEnabled(): Boolean = isLevelEnabled(TRACE)

--- a/src/commonMain/kotlin/io/klogging/Klogger.kt
+++ b/src/commonMain/kotlin/io/klogging/Klogger.kt
@@ -30,34 +30,43 @@ import io.klogging.events.LogEvent
  * Logger interface for sending log events inside coroutines.
  */
 public interface Klogger : BaseLogger {
-
     public suspend fun emitEvent(level: Level, exception: Exception?, event: Any?)
 
-    public suspend fun log(level: Level, exception: Exception, event: Any?): Unit =
+    public suspend fun log(level: Level, exception: Exception, event: Any?) {
+        if (!isLevelEnabled(level)) return
         emitEvent(level, exception, event)
+    }
 
-    public suspend fun log(level: Level, event: Any?): Unit =
+    public suspend fun log(level: Level, event: Any?) {
+        if (!isLevelEnabled(level)) return
         emitEvent(level, null, event)
+    }
 
     public suspend fun log(
         level: Level,
         exception: Exception,
         template: String,
         vararg values: Any?
-    ): Unit =
+    ) {
+        if (!isLevelEnabled(level)) return
         if (values.isEmpty()) emitEvent(level, exception, template)
         else emitEvent(level, exception, e(template, *values))
+    }
 
-    public suspend fun log(level: Level, template: String, vararg values: Any?): Unit =
+    public suspend fun log(level: Level, template: String, vararg values: Any?) {
+        if (!isLevelEnabled(level)) return
         if (values.isEmpty()) emitEvent(level, null, template)
         else emitEvent(level, null, e(template, *values))
+    }
 
     public suspend fun log(level: Level, exception: Exception, event: suspend Klogger.() -> Any?) {
-        if (isLevelEnabled(level)) emitEvent(level, exception, event())
+        if (!isLevelEnabled(level)) return
+        emitEvent(level, exception, event())
     }
 
     public suspend fun log(level: Level, event: suspend Klogger.() -> Any?) {
-        if (isLevelEnabled(level)) emitEvent(level, null, event())
+        if (!isLevelEnabled(level)) return
+        emitEvent(level, null, event())
     }
 
     public suspend fun trace(event: Any?): Unit = log(TRACE, event)

--- a/src/jvmTest/kotlin/io/klogging/KloggerTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/KloggerTest.kt
@@ -31,9 +31,9 @@ import io.klogging.events.timestampNow
 import io.klogging.template.templateItems
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.maps.shouldContain
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import java.lang.Thread.currentThread
-import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
 class TestLogger(private val minLevel: Level = TRACE) : Klogger {
@@ -68,8 +68,38 @@ class TestException(message: String) : Exception(message)
 class KloggerTest : DescribeSpec({
     // Capture once rather than call several times: Avoid flaky tests if the OS sleeps our process
     val now = timestampNow()
+    val thing = object {
+        override fun toString() = "foo"
+    }
 
     describe("KtLogger") {
+        describe("does not log") {
+            it("for a string message") {
+                with(TestLogger()) {
+                    log(NONE, "foo")
+                    logged.shouldBeNull()
+                }
+            }
+            it("for a string message with an exception") {
+                with(TestLogger()) {
+                    log(NONE, TestException("low bar"), "foo")
+                    logged.shouldBeNull()
+                }
+            }
+            it("for an object") {
+                with(TestLogger()) {
+                    log(NONE, thing)
+                    logged.shouldBeNull()
+                }
+            }
+            it("for an object with an exception") {
+                with(TestLogger()) {
+                    log(NONE, TestException("low bar"), thing)
+                    logged.shouldBeNull()
+                }
+            }
+        }
+
         describe("for different logging styles") {
             it("logs a string message") {
                 val message = randomString()
@@ -87,14 +117,14 @@ class KloggerTest : DescribeSpec({
                     logged shouldBe message
                 }
             }
-            it("logs a string message in a lambda") {
+            it("logs a string message in a code block") {
                 val message = randomString()
                 with(TestLogger()) {
                     info { message }
                     logged shouldBe message
                 }
             }
-            it("logs a string message in a lambda with an exception") {
+            it("logs a string message in a code block with an exception") {
                 val message = randomString()
                 val exception = TestException(randomString())
                 with(TestLogger()) {
@@ -105,12 +135,11 @@ class KloggerTest : DescribeSpec({
             }
             it("logs an object") {
                 with(TestLogger()) {
-                    log(DEBUG, now)
-                    logged shouldBe now
+                    log(DEBUG, thing)
+                    logged shouldBe thing
                 }
             }
             it("logs an object with an exception") {
-                val thing = listOf(randomString(), randomString())
                 val exception = TestException(randomString())
                 with(TestLogger()) {
                     log(WARN, exception, thing)
@@ -118,15 +147,13 @@ class KloggerTest : DescribeSpec({
                     logged shouldBe thing
                 }
             }
-            it("logs an object in a lambda") {
-                val thing = randomString() to now
+            it("logs an object in a code block") {
                 with(TestLogger()) {
                     info { thing }
                     logged shouldBe thing
                 }
             }
             it("logs an object in a lambda with an exception") {
-                val thing = setOf(now - Duration.seconds(5), now)
                 val exception = TestException(randomString())
                 with(TestLogger()) {
                     error(exception) { thing }
@@ -162,7 +189,7 @@ class KloggerTest : DescribeSpec({
                     }
                 }
             }
-            it("logs a templated event using `e()` function in a lambda") {
+            it("logs a templated event using `e()` function in a code block") {
                 val template = "Id is {Id}"
                 val id = randomString()
                 with(TestLogger()) {
@@ -174,7 +201,7 @@ class KloggerTest : DescribeSpec({
                     }
                 }
             }
-            it("logs a templated event using `e()` function in a lambda with an exception") {
+            it("logs a templated event using `e()` function in a code block with an exception") {
                 val id = randomString()
                 val exception = TestException(randomString())
                 with(TestLogger()) {

--- a/src/jvmTest/kotlin/io/klogging/KloggerTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/KloggerTest.kt
@@ -73,7 +73,7 @@ class KloggerTest : DescribeSpec({
     }
 
     describe("KtLogger") {
-        describe("does not log") {
+        describe("does not log when level is NONE") {
             it("for a string message") {
                 with(TestLogger()) {
                     log(NONE, "foo")

--- a/src/jvmTest/kotlin/io/klogging/LevelsTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/LevelsTest.kt
@@ -32,10 +32,10 @@ internal class LevelsTest : DescribeSpec({
                     randomString().let { message ->
                         logger.log(eventLevel, message)
 
-                        if (!logger.isLevelEnabled(eventLevel))
-                            logger.loggedMessage.shouldBeNull()
-                        else
+                        if (logger.isLevelEnabled(eventLevel))
                             logger.loggedMessage shouldBe message
+                        else
+                            logger.loggedMessage.shouldBeNull()
                     }
                 }
             }

--- a/src/jvmTest/kotlin/io/klogging/LevelsTest.kt
+++ b/src/jvmTest/kotlin/io/klogging/LevelsTest.kt
@@ -20,9 +20,30 @@ package io.klogging
 
 import io.klogging.events.LogEvent
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 
-class LevelsTestLogger(private val level: Level) : Klogger {
+internal class LevelsTest : DescribeSpec({
+    describe("at all logger levels") {
+        it("`log()` calls `logMessage()` for all levels") {
+            Level.values().forEach { loggerLevel ->
+                val logger = LevelsTestLogger(loggerLevel)
+                Level.values().forEach { eventLevel ->
+                    randomString().let { message ->
+                        logger.log(eventLevel, message)
+
+                        if (!logger.isLevelEnabled(eventLevel))
+                            logger.loggedMessage.shouldBeNull()
+                        else
+                            logger.loggedMessage shouldBe message
+                    }
+                }
+            }
+        }
+    }
+})
+
+private class LevelsTestLogger(private val level: Level) : Klogger {
     override val name = "LevelsTestLogger"
 
     override fun minLevel() = level
@@ -37,19 +58,3 @@ class LevelsTestLogger(private val level: Level) : Klogger {
         TODO("Not yet implemented")
     }
 }
-
-class LevelsTest : DescribeSpec({
-    describe("at all logger levels") {
-        it("`log()` calls `logMessage()` for all levels") {
-            Level.values().forEach { loggerLevel ->
-                val logger = LevelsTestLogger(loggerLevel)
-                Level.values().forEach { eventLevel ->
-                    randomString().let { msg ->
-                        logger.log(eventLevel, msg)
-                        logger.loggedMessage shouldBe msg
-                    }
-                }
-            }
-        }
-    }
-})


### PR DESCRIPTION
Several commits together.  Key points:

- I started from writing tests, and wound up with the below to get the tests passing (see "does not log" block of tests)
- **IMPORTANT** -- please review how `NONE` is handled, especially for:
   `public fun isLevelEnabled(level: Level): Boolean = NONE != level && minLevel() <= level`
- Short-circuit checks in methods like `log` to skip processing if the log level is disabled
- Formatting courtesy of IntelliJ
- Remove useless code in `batect.yml` (which I added myself previously: I had not noticed the `GRADLE_OPTS` env var)