### PR TITLE
Add CI build step for all target platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         run: ./batect generateCodeCoverageReport
 
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v2.0.2
+        uses: codecov/codecov-action@v2.0.3
 
       - name: Assemble release
         run: ./batect assembleRelease

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,3 +97,35 @@ jobs:
           rm -rf .batect/caches/gradle-cache/daemon/*/*.lock
           rm -rf .batect/caches/gradle-cache/daemon/*/*.log
           rm -rf .batect/caches/gradle-cache/kotlin-profile/*
+
+  ci-build:
+    name: "Build all platform targets (JVM, JS, Native on Linux)"
+    runs-on: ubuntu-latest
+    env:
+      TERM: xterm-256color
+      BATECT_CACHE_TYPE: directory
+      BATECT_ENABLE_TELEMETRY: true
+      SIGNING_KEY_ID: 40D4E7C6
+      OSSRH_USERNAME: mjstrasser
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Cache Batect
+        uses: actions/cache@v2
+        with:
+          path: ~/.batect/cache
+          key: batect-${{ hashFiles('batect') }}
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        id: cache-dependencies
+        with:
+          path: .batect/caches
+          key: batect-caches-${{ hashFiles('**/*.gradle.kts') }}
+
+      - name: Build
+        run: ./batect build-all-platform-targets

--- a/batect
+++ b/batect
@@ -8,8 +8,8 @@
     # You should commit this file to version control alongside the rest of your project. It should not be installed globally.
     # For more information, visit https://github.com/batect/batect.
 
-    VERSION="0.72.0"
-    CHECKSUM="${BATECT_DOWNLOAD_CHECKSUM:-477672af8d8d493bbb209269cb0392e4d054ffe527cf22d78b61d294b5adfdeb}"
+    VERSION="0.73.0"
+    CHECKSUM="${BATECT_DOWNLOAD_CHECKSUM:-1a9bb210e2904d571ba1f4073ab4a74ab54dc551d0c2f1e60eb5b6883b548b23}"
     DOWNLOAD_URL_ROOT=${BATECT_DOWNLOAD_URL_ROOT:-"https://updates.batect.dev/v1/files"}
     DOWNLOAD_URL=${BATECT_DOWNLOAD_URL:-"$DOWNLOAD_URL_ROOT/$VERSION/batect-$VERSION.jar"}
     QUIET_DOWNLOAD=${BATECT_QUIET_DOWNLOAD:-false}
@@ -83,7 +83,7 @@
             JAVA_OPTS=()
         fi
 
-        if [[ "$(uname -o 2>&1)" == "Msys" ]] && hash winpty 2>/dev/null; then
+        if [[ "$(uname -o 2>&1)" == "Msys" ]] && hash winpty 2>/dev/null && [ -t /dev/stdin ]; then
             GIT_BASH_PTY_WORKAROUND=(winpty)
         else
             GIT_BASH_PTY_WORKAROUND=()

--- a/batect.cmd
+++ b/batect.cmd
@@ -6,7 +6,7 @@ rem For more information, visit https://github.com/batect/batect.
 
 setlocal EnableDelayedExpansion
 
-set "version=0.72.0"
+set "version=0.73.0"
 
 if "%BATECT_CACHE_DIR%" == "" (
     set "BATECT_CACHE_DIR=%USERPROFILE%\.batect\cache"
@@ -22,7 +22,7 @@ $ErrorActionPreference = 'Stop'^
 
 ^
 
-$Version='0.72.0'^
+$Version='0.73.0'^
 
 ^
 
@@ -48,7 +48,7 @@ $UrlEncodedVersion = [Uri]::EscapeDataString($Version)^
 
 $DownloadUrl = getValueOrDefault $env:BATECT_DOWNLOAD_URL "$DownloadUrlRoot/$UrlEncodedVersion/batect-$UrlEncodedVersion.jar"^
 
-$ExpectedChecksum = getValueOrDefault $env:BATECT_DOWNLOAD_CHECKSUM '477672af8d8d493bbb209269cb0392e4d054ffe527cf22d78b61d294b5adfdeb'^
+$ExpectedChecksum = getValueOrDefault $env:BATECT_DOWNLOAD_CHECKSUM '1a9bb210e2904d571ba1f4073ab4a74ab54dc551d0c2f1e60eb5b6883b548b23'^
 
 ^
 

--- a/batect.yml
+++ b/batect.yml
@@ -30,6 +30,11 @@ tasks:
       container: build-env
       command: ./gradlew check
 
+  build-all-platform-targets:
+    run:
+      container: build-env
+      command: ./gradlew build
+
   continuousCheck:
     description: Run 'check' and then re-run when any code changes are detected.
     run:


### PR DESCRIPTION
2 commits:
- Bump Batect to latest (housekeeping)
- Bump Codecov in CI build (housekeeping)
- Specifically run `./gradlew build` which builds for JS, JVM, and Native

If you prefer, I can split this to 2 PRs.  I understand that you have trouble with the Gradle `build` task on your machine.