### PR TITLE
Fix #192: Map (DEFAULT|ANSI)_CONSOLE to STDERR_(SIMPLE|ANSI) instead of STDOUT_(SIMPLE|ANSI)

### DIFF
--- a/klogging/api/klogging.api
+++ b/klogging/api/klogging.api
@@ -280,6 +280,8 @@ public abstract interface annotation class io/klogging/config/ConfigDsl : java/l
 public final class io/klogging/config/DefaultsKt {
 	public static final fun getANSI_CONSOLE ()Lkotlin/jvm/functions/Function1;
 	public static final fun getDEFAULT_CONSOLE ()Lkotlin/jvm/functions/Function1;
+	public static final fun getSTDERR_ANSI ()Lio/klogging/config/SinkConfiguration;
+	public static final fun getSTDERR_SIMPLE ()Lio/klogging/config/SinkConfiguration;
 	public static final fun getSTDOUT_ANSI ()Lio/klogging/config/SinkConfiguration;
 	public static final fun getSTDOUT_SIMPLE ()Lio/klogging/config/SinkConfiguration;
 }

--- a/klogging/src/commonMain/kotlin/io/klogging/config/Defaults.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/config/Defaults.kt
@@ -21,20 +21,25 @@ package io.klogging.config
 import io.klogging.Level.INFO
 import io.klogging.rendering.RENDER_ANSI
 import io.klogging.rendering.RENDER_SIMPLE
+import io.klogging.sending.STDERR
 import io.klogging.sending.STDOUT
 
 /** Simple sink configuration for rendering simple strings to the standard output stream. */
 public val STDOUT_SIMPLE: SinkConfiguration =
     SinkConfiguration(RENDER_SIMPLE, STDOUT)
 
+/** Simple sink configuration for rendering simple strings to the standard error stream. */
+public val STDERR_SIMPLE: SinkConfiguration =
+    SinkConfiguration(RENDER_SIMPLE, STDERR)
+
 /**
- * Simple default configuration for logging to the standard output stream.
+ * Simple default configuration for logging to the standard error stream.
  *
  * - All loggers are included.
  * - All events at [INFO] or higher level are included.
  */
 public val DEFAULT_CONSOLE: KloggingConfiguration.() -> Unit = {
-    sink("console", STDOUT_SIMPLE)
+    sink("console", STDERR_SIMPLE)
     logging { fromMinLevel(INFO) { toSink("console") } }
 }
 
@@ -42,13 +47,17 @@ public val DEFAULT_CONSOLE: KloggingConfiguration.() -> Unit = {
 public val STDOUT_ANSI: SinkConfiguration =
     SinkConfiguration(RENDER_ANSI, STDOUT)
 
+/** Simple sink configuration for rendering ANSI-coloured strings to the standard error stream. */
+public val STDERR_ANSI: SinkConfiguration =
+    SinkConfiguration(RENDER_ANSI, STDERR)
+
 /**
- * Simple default configuration for logging ANSI-coloured strings to the standard output stream.
+ * Simple default configuration for logging ANSI-coloured strings to the standard error stream.
  *
  * - All loggers are included.
  * - All events at [INFO] or higher level are included.
  */
 public val ANSI_CONSOLE: KloggingConfiguration.() -> Unit = {
-    sink("console", STDOUT_ANSI)
+    sink("console", STDERR_ANSI)
     logging { fromMinLevel(INFO) { toSink("console") } }
 }

--- a/klogging/src/jvmTest/kotlin/io/klogging/config/HoconConfigurationTest.kt
+++ b/klogging/src/jvmTest/kotlin/io/klogging/config/HoconConfigurationTest.kt
@@ -27,7 +27,7 @@ import io.klogging.genString
 import io.klogging.internal.KloggingEngine
 import io.klogging.rendering.RENDER_CLEF
 import io.klogging.rendering.RENDER_SIMPLE
-import io.klogging.sending.STDOUT
+import io.klogging.sending.STDERR
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.maps.shouldHaveSize
@@ -65,7 +65,7 @@ internal class HoconConfigurationTest : DescribeSpec({
                     sinks.keys.first() shouldBe "console"
                     with(sinks.values.first()) {
                         renderer shouldBe RENDER_SIMPLE
-                        stringSender shouldBe STDOUT
+                        stringSender shouldBe STDERR
                     }
                 }
             }
@@ -76,7 +76,7 @@ internal class HoconConfigurationTest : DescribeSpec({
                       sinks: {
                         stdout: {
                           renderWith: RENDER_SIMPLE,
-                          sendTo: STDOUT
+                          sendTo: STDERR
                         }
                       }
                     }
@@ -91,9 +91,9 @@ internal class HoconConfigurationTest : DescribeSpec({
                 {
                   minDirectLogLevel: INFO,
                   sinks: {
-                    stdout: {
+                    stderr: {
                       renderWith: RENDER_SIMPLE,
-                      sendTo: STDOUT
+                      sendTo: STDERR
                     }
                   },
                   logging: [
@@ -103,7 +103,7 @@ internal class HoconConfigurationTest : DescribeSpec({
                         {
                           fromMinLevel: INFO,
                           toSinks: [
-                            stdout
+                            stderr
                           ]
                         }
                       ]
@@ -118,10 +118,10 @@ internal class HoconConfigurationTest : DescribeSpec({
                 hoconConfig?.apply {
                     minDirectLogLevel shouldBe INFO
                     sinks shouldHaveSize 1
-                    sinks.keys.first() shouldBe "stdout"
+                    sinks.keys.first() shouldBe "stderr"
                     with(sinks.values.first()) {
                         renderWith shouldBe "RENDER_SIMPLE"
-                        sendTo shouldBe "STDOUT"
+                        sendTo shouldBe "STDERR"
                     }
                     logging shouldHaveSize 1
                     with(logging.first()) {
@@ -132,7 +132,7 @@ internal class HoconConfigurationTest : DescribeSpec({
                             with(toSinks) {
                                 shouldNotBeNull()
                                 shouldHaveSize(1)
-                                first() shouldBe "stdout"
+                                first() shouldBe "stderr"
                             }
                         }
                     }
@@ -143,10 +143,10 @@ internal class HoconConfigurationTest : DescribeSpec({
 
                 config?.apply {
                     sinks shouldHaveSize 1
-                    sinks.keys.first() shouldBe "stdout"
+                    sinks.keys.first() shouldBe "stderr"
                     with(sinks.values.first()) {
                         renderer shouldBe RENDER_SIMPLE
-                        stringSender shouldBe STDOUT
+                        stringSender shouldBe STDERR
                     }
                 }
             }
@@ -161,7 +161,7 @@ internal class HoconConfigurationTest : DescribeSpec({
                         with(ranges.first()) {
                             minLevel shouldBe INFO
                             maxLevel shouldBe FATAL
-                            sinkNames shouldBe listOf("stdout")
+                            sinkNames shouldBe listOf("stderr")
                         }
                     }
                 }
@@ -194,18 +194,18 @@ internal class HoconConfigurationTest : DescribeSpec({
                     val sinkConfig = parseSinkConfig(
                         """{
                                 renderWith: RENDER_SIMPLE,
-                                sendTo: STDOUT
+                                sendTo: STDERR
                             }
                         """.trimIndent(),
                     )
 
                     sinkConfig?.renderer shouldBe RENDER_SIMPLE
-                    sinkConfig?.stringSender shouldBe STDOUT
+                    sinkConfig?.stringSender shouldBe STDERR
                 }
                 it("returns null if `renderWith` key is missing") {
                     val sinkConfig = parseSinkConfig(
                         """{
-                            sendTo: STDOUT
+                            sendTo: STDERR
                         }
                         """.trimIndent(),
                     )
@@ -265,7 +265,7 @@ internal class HoconConfigurationTest : DescribeSpec({
                         """.trimIndent(),
                     )
 
-                    sinkConfig?.stringSender shouldNotBe STDOUT
+                    sinkConfig?.stringSender shouldNotBe STDERR
                 }
             }
         }

--- a/klogging/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
+++ b/klogging/src/jvmTest/kotlin/io/klogging/config/JsonConfigurationTest.kt
@@ -27,6 +27,7 @@ import io.klogging.genString
 import io.klogging.internal.KloggingEngine
 import io.klogging.rendering.RENDER_CLEF
 import io.klogging.rendering.RENDER_SIMPLE
+import io.klogging.sending.STDERR
 import io.klogging.sending.STDOUT
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -63,7 +64,7 @@ internal class JsonConfigurationTest : DescribeSpec({
                     sinks.keys.first() shouldBe "console"
                     with(sinks.values.first()) {
                         renderer shouldBe RENDER_SIMPLE
-                        stringSender shouldBe STDOUT
+                        stringSender shouldBe STDERR
                     }
                 }
             }

--- a/klogging/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
+++ b/klogging/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
@@ -56,17 +56,17 @@ internal class KloggingConfigurationTest : DescribeSpec({
             it("adds sinks to the map") {
                 val sinkConfig = seq("http://localhost:5341")
                 loggingConfiguration {
-                    sink("console", STDOUT_SIMPLE)
+                    sink("console", STDERR_SIMPLE)
                     sink("seq", sinkConfig)
                 }
-                KloggingEngine.sinkConfigs() shouldContain ("console" to STDOUT_SIMPLE)
+                KloggingEngine.sinkConfigs() shouldContain ("console" to STDERR_SIMPLE)
                 KloggingEngine.sinkConfigs() shouldContain ("seq" to sinkConfig)
             }
             it("adds the default console") {
                 loggingConfiguration { DEFAULT_CONSOLE() }
 
                 with(KloggingEngine) {
-                    sinkConfigs() shouldContain ("console" to STDOUT_SIMPLE)
+                    sinkConfigs() shouldContain ("console" to STDERR_SIMPLE)
                     configs() shouldHaveSize 1
                     with(configs().first()) {
                         nameMatcher shouldBe MATCH_ALL


### PR DESCRIPTION
Fixes #192 by adding STDERR_SIMPLE and STDERR_ANSI and changing DEFAULT_CONSOLE and ANSI_CONSOLE to use STDERR_SIMPLE and STDERR_ANSI instead of STDOUT_SIMPLE and STDOUT_ANSI.