### PR TITLE
feat: add standard json structured logging

### DIFF
--- a/klogging/api/klogging.api
+++ b/klogging/api/klogging.api
@@ -883,10 +883,6 @@ public final class io/klogging/rendering/RenderClefKt {
 	public static final fun getRENDER_CLEF ()Lio/klogging/rendering/RenderString;
 }
 
-public final class io/klogging/rendering/RenderStandardKt {
-	public static final fun getRENDER_STANDARD ()Lio/klogging/rendering/RenderString;
-}
-
 public final class io/klogging/rendering/RenderEcsDotNetKt {
 	public static final fun getRENDER_ECS_DOTNET ()Lio/klogging/rendering/RenderString;
 }
@@ -912,6 +908,10 @@ public final class io/klogging/rendering/RenderIso8601Kt {
 public final class io/klogging/rendering/RenderSimpleKt {
 	public static final fun getLocalString (Lkotlinx/datetime/Instant;)Ljava/lang/String;
 	public static final fun getRENDER_SIMPLE ()Lio/klogging/rendering/RenderString;
+}
+
+public final class io/klogging/rendering/RenderStandardKt {
+	public static final fun getRENDER_STANDARD ()Lio/klogging/rendering/RenderString;
 }
 
 public abstract interface class io/klogging/rendering/RenderString {

--- a/klogging/api/klogging.api
+++ b/klogging/api/klogging.api
@@ -883,6 +883,10 @@ public final class io/klogging/rendering/RenderClefKt {
 	public static final fun getRENDER_CLEF ()Lio/klogging/rendering/RenderString;
 }
 
+public final class io/klogging/rendering/RenderStandardKt {
+	public static final fun getRENDER_STANDARD ()Lio/klogging/rendering/RenderString;
+}
+
 public final class io/klogging/rendering/RenderEcsDotNetKt {
 	public static final fun getRENDER_ECS_DOTNET ()Lio/klogging/rendering/RenderString;
 }

--- a/klogging/src/commonMain/kotlin/io/klogging/config/BuiltIns.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/config/BuiltIns.kt
@@ -24,6 +24,7 @@ import io.klogging.rendering.RENDER_ECS
 import io.klogging.rendering.RENDER_ECS_DOTNET
 import io.klogging.rendering.RENDER_GELF
 import io.klogging.rendering.RENDER_ISO8601
+import io.klogging.rendering.RENDER_STANDARD
 import io.klogging.rendering.RENDER_SIMPLE
 import io.klogging.rendering.RenderString
 import io.klogging.sending.STDERR

--- a/klogging/src/commonMain/kotlin/io/klogging/config/BuiltIns.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/config/BuiltIns.kt
@@ -50,6 +50,7 @@ internal val builtInRenderers: Map<String, RenderString> by lazy {
         "RENDER_GELF" to RENDER_GELF,
         "RENDER_ECS" to RENDER_ECS,
         "RENDER_ECS_DOTNET" to RENDER_ECS_DOTNET,
+        "RENDER_STANDARD" to RENDER_STANDARD,
     )
 }
 

--- a/klogging/src/commonMain/kotlin/io/klogging/rendering/RenderStandard.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/rendering/RenderStandard.kt
@@ -1,0 +1,45 @@
+/*
+
+   Copyright 2024 Baris Ceviz.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package io.klogging.rendering
+
+import io.klogging.events.LogEvent
+
+/**
+ * Render a [LogEvent] into structured JSON log format.
+ *
+ * - If `context` is not null, include it with key `context`.
+ * - If `stackTrace` is not null, include it with key `stackTrace`.
+ */
+public val RENDER_STANDARD: RenderString = object : RenderString {
+    override fun invoke(event: LogEvent): String {
+        val eventMap: MutableMap<String, Any?> = (
+                mapOf(
+                    "timestamp" to event.timestamp.toString(),
+                    "level" to event.level.name,
+                    "host" to event.host,
+                    "logger" to event.logger,
+                ) + event.items
+                ).toMutableMap()
+        if (event.context != null) eventMap["context"] = event.context
+        eventMap["message"] = event.message
+        if (event.stackTrace != null) eventMap["stackTrace"] = event.stackTrace
+
+        return serializeMap(eventMap)
+    }
+}

--- a/klogging/src/jvmTest/kotlin/io/klogging/rendering/RenderStandardTest.kt
+++ b/klogging/src/jvmTest/kotlin/io/klogging/rendering/RenderStandardTest.kt
@@ -1,0 +1,102 @@
+/*
+
+   Copyright 2024 Baris Ceviz.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package io.klogging.rendering
+
+import io.klogging.Level.INFO
+import io.klogging.events.LogEvent
+import io.klogging.events.threadContext
+import io.klogging.events.timestampNow
+import io.klogging.randomString
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class RenderStandardTest : DescribeSpec({
+    describe("Render a `LogEvent` to STANDARD") {
+        it("omits stackTrace if `stackTrace` is null") {
+            val ts = timestampNow()
+            val event = LogEvent(
+                randomString(), ts, "test.local", "Test", threadContext(), INFO,
+                null, "Message", null, mapOf(),
+            )
+
+            RENDER_STANDARD(event) shouldBe """{
+            |"timestamp":"${event.timestamp}",
+            |"level":"${event.level}",
+            |"host":"${event.host}",
+            |"logger":"${event.logger}",
+            |"context":"${event.context}",
+            |"message":"${event.message}"
+            |}
+            """.trimMargin().replace("\n", "")
+        }
+        it("includes stackTrace if `stackTrace` is present") {
+            val ts = timestampNow()
+            val trace = randomString()
+            val event =
+                LogEvent(
+                    randomString(), ts, "test.local", "Test", threadContext(), INFO,
+                    null, "Message", trace, mapOf(),
+                )
+
+            RENDER_STANDARD(event) shouldBe """{
+            |"timestamp":"${event.timestamp}",
+            |"level":"${event.level}",
+            |"host":"${event.host}",
+            |"logger":"${event.logger}",
+            |"context":"${event.context}",
+            |"message":"${event.message}",
+            |"stackTrace":"${event.stackTrace}"
+            |}
+            """.trimMargin().replace("\n", "")
+        }
+        it("includes message") {
+            val ts = timestampNow()
+            val event = LogEvent(
+                randomString(), ts, "test.local", "Test", threadContext(), INFO,
+                null, "Message", null, mapOf(),
+            )
+
+            RENDER_STANDARD(event) shouldBe """{
+            |"timestamp":"${event.timestamp}",
+            |"level":"${event.level}",
+            |"host":"${event.host}",
+            |"logger":"${event.logger}",
+            |"context":"${event.context}",
+            |"message":"${event.message}"
+            |}
+            """.trimMargin().replace("\n", "")
+        }
+        it("omits context if the event `context` is null") {
+            val ts = timestampNow()
+            val event = LogEvent(
+                randomString(), ts, "test.local", "Test", null, INFO,
+                null, "Message", null, mapOf(),
+            )
+
+            RENDER_STANDARD(event) shouldBe """{
+            |"timestamp":"${event.timestamp}",
+            |"level":"${event.level}",
+            |"host":"${event.host}",
+            |"logger":"${event.logger}",
+            |"message":"${event.message}"
+            |}
+            """.trimMargin().replace("\n", "")
+        }
+    }
+})


### PR DESCRIPTION
Hi Klogging maintianers,

I created a new renderer. It's covering common logging processors like Datadog, New Relic etc. Any render type of klogging is not covering popular APM tools. For example; Datadog cannot detect the level of logs. I implemented standard structured JSON logging.