### PR TITLE
Fix publish task dependency conflicts, add publishing of iOS artifacts

### DIFF
--- a/.github/workflows/build-klogging.yml
+++ b/.github/workflows/build-klogging.yml
@@ -72,9 +72,51 @@ jobs:
         if: steps.check_test_output.outputs.files_exists == 'true'
 
       - name: Publish Klogging snapshot
-        run: ./gradlew :klogging:publishJvmPublicationToSnapshotsRepository
+        run: ./gradlew :klogging:publishAllPublicationsToSnapshotsRepository
+        if: github.repository == 'kvaster/klogging' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+
+      - name: Publish Klogging release
+        run: ./gradlew :klogging:publishAllPublicationToReleaseRepository
+        if: github.repository == 'kvaster/klogging' && startsWith(github.ref, 'refs/tags/') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+
+  build-klogging-apple:
+    name: Build apple versions of Klogging library
+    runs-on: macos-latest
+    needs: build-klogging
+    env:
+      SIGNING_KEY_ID: 40D4E7C6
+      OSSRH_USERNAME: mjstrasser
+      OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+      TERM: xterm-256color
+      KLOGGING_MIN_LOG_LEVEL: WARN # Reduce noise in test output
+
+    permissions:
+      contents: write # Required to be able to publish releases, see https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-contents
+      checks: write # Required to write test reports.
+      statuses: write
+      pull-requests: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Check out everything including tags
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Publish Klogging snapshot
+        run: ./gradlew :klogging:publishIosArm64PublicationToSnapshotsRepository :klogging:publishIosX64PublicationToSnapshotsRepository :klogging:publishIosSimulatorArm64PublicationToSnapshotsRepository
         if: github.repository == 'klogging/klogging' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
 
       - name: Publish Klogging release
-        run: ./gradlew :klogging:publishJvmPublicationToSnapshotsRepository
+        run: ./gradlew :klogging:publishIosArm64PublicationToReleaseRepository :klogging:publishIosX64PublicationToReleaseRepository :klogging:publishIosSimulatorArm64PublicationToReleaseRepository
         if: github.repository == 'klogging/klogging' && startsWith(github.ref, 'refs/tags/') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -42,3 +42,32 @@ jobs:
 
       - name: Code coverage
         run: ./gradlew koverHtmlReport
+
+  build-klogging-apple:
+    name: Build apple versions of Klogging library from a PR
+    runs-on: macos-latest
+    env:
+      TERM: xterm-256color
+      KLOGGING_MIN_LOG_LEVEL: WARN # Reduce noise in test output
+
+    permissions:
+      statuses: write
+      pull-requests: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Check out everything including tags
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew clean :klogging:linkReleaseFrameworkIosArm64 :klogging:linkReleaseFrameworkIosX64 :klogging:linkReleaseFrameworkIosSimulatorArm64

--- a/convention-plugins/src/main/kotlin/klogging-publishing.gradle.kts
+++ b/convention-plugins/src/main/kotlin/klogging-publishing.gradle.kts
@@ -23,10 +23,6 @@ plugins {
 
 group = "io.klogging"
 
-val javadocJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("javadoc")
-}
-
 fun getExtraString(name: String) = extra[name]?.toString()
 
 publishing {
@@ -52,9 +48,6 @@ publishing {
 
     // Configure all publications
     publications.withType<MavenPublication> {
-        // Stub javadoc.jar artifact
-        artifact(javadocJar.get())
-
         // Provide artifacts information requited by Maven Central
         pom {
             name.set("klogging")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ binary-compatibility-validator = "0.16.3"
 dokka = "1.9.20"
 hexagon = { strictly = "3.4.7" }
 html-reporter = "0.7.1"
-kotlin = "2.0.20"
+kotlin = "2.1.0-Beta1"
 kotest = "5.9.1"
 kover = "0.8.3"
 kotlin-coroutines = "1.9.0"

--- a/klogging/build.gradle.kts
+++ b/klogging/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
     }
 
     androidTarget {
-        publishLibraryVariants("release")
+        publishLibraryVariants("release", "debug")
     }
 
     listOf(

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1170,6 +1170,13 @@ kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+kotlin-web-helpers@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-2.0.0.tgz#b112096b273c1e733e0b86560998235c09a19286"
+  integrity sha512-xkVGl60Ygn/zuLkDPx+oHj7jeLR7hCvoNF99nhwXMn8a3ApB4lLiC9pk4ol4NHPjyoCbvQctBqvzUcp8pkqyWw==
+  dependencies:
+    format-util "^1.0.5"
+
 loader-runner@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"


### PR DESCRIPTION
It seems that gradle becomes crazy with publishing signed artifacts in case there is 'common' artifact for different platform: https://github.com/gradle/gradle/issues/26091#issuecomment-1836156762

Removing javadoc stub fixes the problem.

Also building iOS/macos artifacts is done using separate pipeline on macos runner.

Also we need to update to kotlin 2.1.0-Beta1 cause of folowing problem: https://youtrack.jetbrains.com/issue/KT-70700/Gradle-8.10-The-value-for-task-commonizeNativeDistribution-property-kotlinNativeBundleBuildService-cannot-be-changed-any-further

Fixes: https://github.com/klogging/klogging/issues/294