### PR TITLE
Non-lazy initialization of MDCAdapter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kotlin-coroutines = "1.10.1"
 kotlin-datetime = "0.6.2"
 kotlin-serialisation = "1.8.0"
 reckon = "0.19.1"
-slf4j = "2.0.16"
+slf4j = "2.0.17"
 spotless = "7.0.2"
 test-logger = "3.2.0"
 android-library = { strictly = "[8.7, 8.8[" }

--- a/slf4j-klogging/src/main/kotlin/io/klogging/slf4j/KloggingServiceProvider.kt
+++ b/slf4j-klogging/src/main/kotlin/io/klogging/slf4j/KloggingServiceProvider.kt
@@ -35,7 +35,7 @@ public const val REQUESTED_API_VERSION: String = "2.0.99"
 public class KloggingServiceProvider : SLF4JServiceProvider {
     private lateinit var loggerFactory: ILoggerFactory
     private lateinit var markerFactory: IMarkerFactory
-    private lateinit var mdcAdapter: MDCAdapter
+    private val mdcAdapter: MDCAdapter = BasicMDCAdapter()
 
     override fun getLoggerFactory(): ILoggerFactory = loggerFactory
 
@@ -48,7 +48,6 @@ public class KloggingServiceProvider : SLF4JServiceProvider {
     override fun initialize() {
         loggerFactory = NoCoLoggerFactory()
         markerFactory = BasicMarkerFactory()
-        mdcAdapter = BasicMDCAdapter()
 
         // Ensure any MDC items are included in every log event, whether an `NoCoLoggerWrapper` or not.
         Context.addItemExtractor {


### PR DESCRIPTION
Fixes #340 

- The upgrade of SLF4J to v2.0.17 reveals the problem by failing tests
- Another commit fixed the problem by making `mdcAdapter` a non-lazy field