### PR TITLE
Make `minimumLevelOf` aware of `stopOnMatch`

### DIFF
--- a/klogging/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
@@ -206,8 +206,7 @@ public class KloggingConfiguration {
      * @return calculated level
      */
     public fun minimumLevelOf(loggerName: String): Level =
-        configs
-            .filter { it.nameMatcher(loggerName) }
+        matchingConfigurationsOf(loggerName)
             .flatMap { it.ranges }
             .minOfOrNull { it.minLevel } ?: NONE
 

--- a/klogging/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
@@ -242,4 +242,23 @@ public class KloggingConfiguration {
             kloggingMinLogLevel = other.kloggingMinLogLevel
         }
     }
+
+
+    /**
+     * Return the [LoggingConfig]s that are matching the given [loggerName]
+     * @param loggerName name of the logger
+     * @return list of filtered configurations
+     */
+    internal fun matchingConfigurationsOf(loggerName:String) :List<LoggingConfig>{
+        var keepMatching = true
+
+        return KloggingEngine
+                .configs()
+                .filter { config ->
+                    val matches = config.nameMatcher(loggerName)
+                    (keepMatching && matches).also {
+                        keepMatching = keepMatching && !(matches && config.stopOnMatch)
+                    }
+                }
+    }
 }

--- a/klogging/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/config/KloggingConfiguration.kt
@@ -248,16 +248,16 @@ public class KloggingConfiguration {
      * @param loggerName name of the logger
      * @return list of filtered configurations
      */
-    internal fun matchingConfigurationsOf(loggerName:String) :List<LoggingConfig>{
+    internal fun matchingConfigurationsOf(loggerName: String): List<LoggingConfig> {
         var keepMatching = true
 
         return KloggingEngine
-                .configs()
-                .filter { config ->
-                    val matches = config.nameMatcher(loggerName)
-                    (keepMatching && matches).also {
-                        keepMatching = keepMatching && !(matches && config.stopOnMatch)
-                    }
+            .configs()
+            .filter { config ->
+                val matches = config.nameMatcher(loggerName)
+                (keepMatching && matches).also {
+                    keepMatching = keepMatching && !(matches && config.stopOnMatch)
                 }
+            }
     }
 }

--- a/klogging/src/commonMain/kotlin/io/klogging/internal/Dispatcher.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/internal/Dispatcher.kt
@@ -104,10 +104,10 @@ internal object Dispatcher {
         level: Level,
     ): List<Sink> {
         val sinkNames = KloggingEngine.matchingConfigurationsOf(loggerName)
-                .flatMap { config -> config.ranges }
-                .filter { range -> level in range }
-                .flatMap { range -> range.sinkNames }
-                .distinct()
+            .flatMap { config -> config.ranges }
+            .filter { range -> level in range }
+            .flatMap { range -> range.sinkNames }
+            .distinct()
         return KloggingEngine
             .sinks()
             .filterKeys { key -> key in sinkNames }

--- a/klogging/src/commonMain/kotlin/io/klogging/internal/Dispatcher.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/internal/Dispatcher.kt
@@ -103,16 +103,8 @@ internal object Dispatcher {
         loggerName: String,
         level: Level,
     ): List<Sink> {
-        var keepMatching = true
-        val sinkNames =
-            KloggingEngine
-                .configs()
-                .filter { config ->
-                    val matches = config.nameMatcher(loggerName)
-                    (keepMatching && matches).also {
-                        keepMatching = keepMatching && !(matches && config.stopOnMatch)
-                    }
-                }.flatMap { config -> config.ranges }
+        val sinkNames = KloggingEngine.matchingConfigurationsOf(loggerName)
+                .flatMap { config -> config.ranges }
                 .filter { range -> level in range }
                 .flatMap { range -> range.sinkNames }
                 .distinct()

--- a/klogging/src/commonMain/kotlin/io/klogging/internal/KloggingEngine.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/internal/KloggingEngine.kt
@@ -137,6 +137,13 @@ internal object KloggingEngine {
     internal fun configs(): List<LoggingConfig> = currentConfig.configs
 
     /**
+     * Return the [LoggingConfig]s that are matching the given [loggerName]
+     * @param loggerName name of the logger
+     * @return list of filtered configurations
+     */
+    internal fun matchingConfigurationsOf(loggerName: String): List<LoggingConfig> = currentConfig.matchingConfigurationsOf(loggerName)
+
+    /**
      * Return the current minimum Klogging internal log [Level].
      * @return minimum level
      */

--- a/klogging/src/commonMain/kotlin/io/klogging/internal/KloggingEngine.kt
+++ b/klogging/src/commonMain/kotlin/io/klogging/internal/KloggingEngine.kt
@@ -141,7 +141,8 @@ internal object KloggingEngine {
      * @param loggerName name of the logger
      * @return list of filtered configurations
      */
-    internal fun matchingConfigurationsOf(loggerName: String): List<LoggingConfig> = currentConfig.matchingConfigurationsOf(loggerName)
+    internal fun matchingConfigurationsOf(loggerName: String): List<LoggingConfig> =
+        currentConfig.matchingConfigurationsOf(loggerName)
 
     /**
      * Return the current minimum Klogging internal log [Level].

--- a/klogging/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
+++ b/klogging/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
@@ -202,6 +202,22 @@ internal class KloggingConfigurationTest :
                             }
                         }
                         KloggingEngine.minimumLevelOf(name) shouldBe INFO
+                        KloggingEngine.minimumLevelOf("$name$name") shouldBe WARN
+                    }
+                }
+                it("returns the minimum level of configurations considering stopOnMatch") {
+                    checkAll(genLoggerName) { name ->
+                        loggingConfiguration {
+                            sink("stdout", RENDER_SIMPLE, STDOUT)
+                            logging {
+                                exactLogger(name, stopOnMatch = true)
+                                atLevel(WARN) { toSink("stdout") }
+                            }
+                            logging { atLevel(INFO) { toSink("stdout") } }
+                        }
+                        // Note: INFO is not taken into account because of stopOnMatch = true
+                        KloggingEngine.minimumLevelOf(name) shouldBe WARN
+                        KloggingEngine.minimumLevelOf("$name$name") shouldBe INFO
                     }
                 }
                 it("returns NONE if no configurations match the event name") {
@@ -216,6 +232,7 @@ internal class KloggingConfigurationTest :
                         KloggingEngine.minimumLevelOf("$name$name") shouldBe NONE
                     }
                 }
+
             }
             describe("append() function") {
                 it("combines sinks") {

--- a/klogging/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
+++ b/klogging/src/jvmTest/kotlin/io/klogging/config/KloggingConfigurationTest.kt
@@ -232,7 +232,6 @@ internal class KloggingConfigurationTest :
                         KloggingEngine.minimumLevelOf("$name$name") shouldBe NONE
                     }
                 }
-
             }
             describe("append() function") {
                 it("combines sinks") {


### PR DESCRIPTION
### Context

Based on the [documentation](https://klogging.io/docs/configuration/dsl/#short-circuit-matching-with-stoponmatch) one should be able to raise the log level of a too verbose logger using `stopOnMatch`:

> ## Short-circuit matching with `stopOnMatch`
> 
> You can reduce log volumes and create detailed logging configurations with short-circuit matching of
> loggers. The logger-matching functions take an optional `stopOnMatch` parameter that specifies
> whether to continue matching or to stop.
> 
> For example:
> 
> ```kotlin
> loggingConfiguration {
>     sink("stdout", RENDER_ANSI, STDOUT)
>     logging {
>         fromLoggerBase("com.example.rest", stopOnMatch = true)
>         fromMinLevel(Level.ERROR) {
>             toSink("stdout")
>         }
>     }
>     logging {
>         fromLoggerBase("com.example")
>         fromMinLevel(Level.DEBUG) {
>             toSink("stdout")
>         }
>     }
> }
> ```
> 
> This configuration specifies:
> 
> - Loggers with names starting with `com.example.rest` log from level `ERROR`.
> - All other loggers with names starting with `com.example` log from level `DEBUG`.
> 
> So logging is as follows:
> 
> | Logger                              | TRACE | DEBUG | INFO | WARN | ERROR | FATAL |
> |-------------------------------------|:-----:|:-----:|:----:|:----:|:-----:|:-----:|
> | `com.example.rest.RestClient`       |       |       |      |      |   ✅   |   ✅   |
> | `com.example.ExampleClass`          |       |   ✅   |  ✅   |  ✅   |   ✅   |   ✅   |
> | `com.example.service.HealthService` |       |   ✅   |  ✅   |  ✅   |   ✅   |   ✅   |
> 
> :::info
> The order of `logging` functions determines when matching stops.
> :::

### Current behavior

`logger("com.example.rest.RestClient").minLogLevel()` is `Level.DEBUG`, because the `minLogLevel()` implementation doesn't consider `stopOnMatch`, it just takes the lowest log levels matching the requested logger name.

### Expected behavior

So I would expect `logger("com.example.rest.RestClient").minLogLevel()` to be `Level.ERROR`. This would allow a lot of CPU cycles can be spared in terms of verbose classes written this way:

```kotlin
val logger = logger("com.example.rest.RestClient")
if (logger.isInfoEnabled()) {
  logger.info("Something computationally expensive: {expensive}", computationallyExpensive())
}
```

### Bugfix

I extracted the configuration matching algorithm from `Dispatcher.kt`:

https://github.com/klogging/klogging/blob/1b9e8e4b4b8d7637cba5bfa1ac8d60544738c79f/klogging/src/commonMain/kotlin/io/klogging/internal/Dispatcher.kt#L102-L123

And then reused it in `KloggingConfiguration.minimumLevelOf()`.